### PR TITLE
refactor: split main.py into separate modules for better organization

### DIFF
--- a/netbox_manager/cli.py
+++ b/netbox_manager/cli.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pkg_resources
+
+import typer
+
+
+def signal_handler_sigint(sig, frame):
+    print("SIGINT received. Exit.")
+    raise typer.Exit()
+
+
+def callback_version(value: bool):
+    if value:
+        print(f"Version {pkg_resources.get_distribution('netbox-manager').version}")
+        raise typer.Exit()

--- a/netbox_manager/config.py
+++ b/netbox_manager/config.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import warnings
+
+from dynaconf import Dynaconf, Validator, ValidationError
+from loguru import logger
+import pynetbox
+import typer
+
+warnings.filterwarnings("ignore")
+
+settings = Dynaconf(
+    envvar_prefix="NETBOX_MANAGER",
+    settings_files=["settings.toml", ".secrets.toml"],
+    load_dotenv=True,
+)
+
+# NOTE: lazy validate configuration
+settings.validators.register(
+    Validator("DEVICETYPE_LIBRARY", is_type_of=str)
+    | Validator("DEVICETYPE_LIBRARY", is_type_of=None, default=None),
+    Validator("MODULETYPE_LIBRARY", is_type_of=str)
+    | Validator("MODULETYPE_LIBRARY", is_type_of=None, default=None),
+    Validator("RESOURCES", is_type_of=str)
+    | Validator("RESOURCES", is_type_of=None, default=None),
+    Validator("TOKEN", is_type_of=str),
+    Validator("URL", is_type_of=str),
+    Validator("IGNORE_SSL_ERRORS", is_type_of=bool)
+    | Validator(
+        "IGNORE_SSL_ERRORS",
+        is_type_of=str,
+        cast=lambda v: v.lower() in ["true", "yes"],
+        default=False,
+    ),
+    Validator("VERBOSE", is_type_of=bool)
+    | Validator(
+        "VERBOSE",
+        is_type_of=str,
+        cast=lambda v: v.lower() in ["true", "yes"],
+        default=False,
+    ),
+)
+
+try:
+    settings.validators.validate_all()
+except ValidationError as e:
+    logger.error(f"Error validating configuration: {e.details}")
+    raise typer.Exit()
+
+nb = pynetbox.api(settings.URL, token=settings.TOKEN)
+
+inventory = {
+    "all": {
+        "hosts": {
+            "localhost": {
+                "ansible_connection": "local",
+                "ansible_python_interpreter": sys.executable,
+            }
+        }
+    }
+}

--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -1,191 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import concurrent.futures
-import glob
-from itertools import groupby
-import os
-import pkg_resources
 import signal
 import sys
-import tempfile
 import time
 from typing import Optional
 from typing_extensions import Annotated
-import warnings
 
-import ansible_runner
-from dynaconf import Dynaconf, Validator, ValidationError
-import git
-from jinja2 import Template
 from loguru import logger
-import pynetbox
 import typer
-import yaml
 
+from .cli import signal_handler_sigint, callback_version
+from .config import settings
 from .dtl import Repo, NetBox
+from .playbook import wait_for_netbox
+from .resources import process_resources
+from .utils import get_changed_files
 
 files_changed: list[str] = []
-
-warnings.filterwarnings("ignore")
-
-settings = Dynaconf(
-    envvar_prefix="NETBOX_MANAGER",
-    settings_files=["settings.toml", ".secrets.toml"],
-    load_dotenv=True,
-)
-
-# NOTE: lazy validate configuration
-settings.validators.register(
-    Validator("DEVICETYPE_LIBRARY", is_type_of=str)
-    | Validator("DEVICETYPE_LIBRARY", is_type_of=None, default=None),
-    Validator("MODULETYPE_LIBRARY", is_type_of=str)
-    | Validator("MODULETYPE_LIBRARY", is_type_of=None, default=None),
-    Validator("RESOURCES", is_type_of=str)
-    | Validator("RESOURCES", is_type_of=None, default=None),
-    Validator("TOKEN", is_type_of=str),
-    Validator("URL", is_type_of=str),
-    Validator("IGNORE_SSL_ERRORS", is_type_of=bool)
-    | Validator(
-        "IGNORE_SSL_ERRORS",
-        is_type_of=str,
-        cast=lambda v: v.lower() in ["true", "yes"],
-        default=False,
-    ),
-    Validator("VERBOSE", is_type_of=bool)
-    | Validator(
-        "VERBOSE",
-        is_type_of=str,
-        cast=lambda v: v.lower() in ["true", "yes"],
-        default=False,
-    ),
-)
-
-try:
-    settings.validators.validate_all()
-except ValidationError as e:
-    logger.error(f"Error validating configuration: {e.details}")
-    raise typer.Exit()
-
-nb = pynetbox.api(settings.URL, token=settings.TOKEN)
-
-inventory = {
-    "all": {
-        "hosts": {
-            "localhost": {
-                "ansible_connection": "local",
-                "ansible_python_interpreter": sys.executable,
-            }
-        }
-    }
-}
-
-playbook_template = """
-- name: Manage NetBox resources defined in {{ name }}
-  connection: local
-  hosts: localhost
-  gather_facts: false
-
-  vars:
-    {{ vars | indent(4) }}
-
-  tasks:
-    {{ tasks | indent(4) }}
-"""
-
-playbook_wait = f"""
-- name: Wait for NetBox service
-  hosts: localhost
-  gather_facts: false
-
-  tasks:
-    - name: Wait for NetBox service REST API
-      ansible.builtin.uri:
-        url: "{settings.URL.rstrip('/')}/api/"
-        headers:
-          Authorization: "Token {settings.TOKEN}"
-          Accept: application/json
-        status_code: [200]
-        validate_certs: {not settings.IGNORE_SSL_ERRORS}
-      register: result
-      retries: 60
-      delay: 5
-      until: result.status == 200 or result.status == 403
-"""
-
-
-def get_leading_number(file: str) -> str:
-    return file.split("-")[0]
-
-
-def handle_file(file: str, dryrun: bool) -> None:
-    template = Template(playbook_template)
-
-    template_vars = {}
-    template_tasks = []
-
-    logger.info(f"Handle file {file}")
-    with open(file) as fp:
-        data = yaml.safe_load(fp)
-        for rtask in data:
-            key, value = next(iter(rtask.items()))
-            if key == "vars":
-                template_vars = value
-            elif key == "debug":
-                task = {"ansible.builtin.debug": value}
-                template_tasks.append(task)
-            else:
-                state = "present"
-                if "state" in value:
-                    state = value["state"]
-                    del value["state"]
-
-                task = {
-                    "name": f"Manage NetBox resource {value.get('name', '')} of type {key}".replace(
-                        "  ", " "
-                    ),
-                    f"netbox.netbox.netbox_{key}": {
-                        "data": value,
-                        "state": state,
-                        "netbox_token": settings.TOKEN,
-                        "netbox_url": settings.URL,
-                        "validate_certs": not settings.IGNORE_SSL_ERRORS,
-                    },
-                }
-                template_tasks.append(task)
-
-    playbook_resources = template.render(
-        {
-            "name": os.path.basename(file),
-            "vars": yaml.dump(template_vars, indent=2, default_flow_style=False),
-            "tasks": yaml.dump(template_tasks, indent=2, default_flow_style=False),
-        }
-    )
-    with tempfile.TemporaryDirectory() as temp_dir:
-        with tempfile.NamedTemporaryFile(
-            mode="w+", suffix=".yml", delete=False
-        ) as temp_file:
-            temp_file.write(playbook_resources)
-
-        if dryrun:
-            logger.info(f"Skip the execution of {file} as only one dry run")
-        else:
-            ansible_runner.run(
-                playbook=temp_file.name,
-                private_data_dir=temp_dir,
-                inventory=inventory,
-                cancel_callback=lambda: None,
-            )
-
-
-def signal_handler_sigint(sig, frame):
-    print("SIGINT received. Exit.")
-    raise typer.Exit()
-
-
-def callback_version(value: bool):
-    if value:
-        print(f"Version {pkg_resources.get_distribution('netbox-manager').version}")
-        raise typer.Exit()
 
 
 def run(
@@ -230,23 +61,7 @@ def run(
 
     # check for changed files
     if not always:
-        try:
-            config_repo = git.Repo(".")
-        except git.exc.InvalidGitRepositoryError:
-            logger.error(
-                "If only changed files are to be processed, the netbox-manager must be called in a Git repository."
-            )
-            raise typer.Exit()
-
-        commit = config_repo.head.commit
-        files_changed = [str(item.a_path) for item in commit.diff(commit.parents[0])]
-
-        if debug:
-            logger.debug(
-                "A list of the changed files follows. Only changed files are processed."
-            )
-            for f in files_changed:
-                logger.debug(f"- {f}")
+        files_changed = get_changed_files(debug)
 
         # skip devicetype library when no files changed there
         if not skipdtl and not any(
@@ -278,26 +93,7 @@ def run(
 
     # wait for NetBox service
     if wait:
-        logger.info("Wait for NetBox service")
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            with tempfile.NamedTemporaryFile(
-                mode="w+", suffix=".yml", delete=False
-            ) as temp_file:
-                temp_file.write(playbook_wait)
-
-            ansible_result = ansible_runner.run(
-                playbook=temp_file.name,
-                private_data_dir=temp_dir,
-                inventory=inventory,
-                cancel_callback=lambda: None,
-            )
-            if (
-                "localhost" in ansible_result.stats["failures"]
-                and ansible_result.stats["failures"]["localhost"] > 0
-            ):
-                logger.error("Failed to establish connection to netbox")
-                raise typer.Exit()
+        wait_for_netbox()
 
     # prepare devicetype and moduletype library
     if (settings.DEVICETYPE_LIBRARY and not skipdtl) or (
@@ -341,46 +137,7 @@ def run(
 
     # manage resources
     if not skipres:
-        logger.info("Manage resources")
-
-        files = []
-        for extension in ["yml", "yaml"]:
-            try:
-                files.extend(
-                    glob.glob(os.path.join(settings.RESOURCES, f"*.{extension}"))
-                )
-            except FileNotFoundError:
-                logger.error(f"Could not load resources in {settings.RESOURCES}")
-
-        if not always:
-            files_filtered = [f for f in files if f in files_changed]
-        else:
-            files_filtered = files
-
-        files_filtered.sort(key=get_leading_number)
-        files_grouped = []
-        for _, group in groupby(files_filtered, key=get_leading_number):
-            files_grouped.append(list(group))
-
-        for group in files_grouped:  # type: ignore[assignment]
-            files_process = []
-            for file in group:
-                if limit and not os.path.basename(file).startswith(limit):
-                    logger.info(f"Skipping {os.path.basename(file)}")
-                    continue
-
-                files_process.append(file)
-
-            if files_process:
-                with concurrent.futures.ThreadPoolExecutor(
-                    max_workers=parallel
-                ) as executor:
-                    futures = [
-                        executor.submit(handle_file, file, dryrun)
-                        for file in files_process
-                    ]
-                    for future in concurrent.futures.as_completed(futures):
-                        future.result()
+        process_resources(files_changed, always, limit, parallel, dryrun)
 
     end = time.time()
     logger.info(f"Runtime: {(end-start):.4f}s")

--- a/netbox_manager/playbook.py
+++ b/netbox_manager/playbook.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import tempfile
+
+import ansible_runner
+from loguru import logger
+import typer
+
+from .config import settings, inventory
+
+playbook_template = """
+- name: Manage NetBox resources defined in {{ name }}
+  connection: local
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    {{ vars | indent(4) }}
+
+  tasks:
+    {{ tasks | indent(4) }}
+"""
+
+playbook_wait = f"""
+- name: Wait for NetBox service
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Wait for NetBox service REST API
+      ansible.builtin.uri:
+        url: "{settings.URL.rstrip('/')}/api/"
+        headers:
+          Authorization: "Token {settings.TOKEN}"
+          Accept: application/json
+        status_code: [200]
+        validate_certs: {not settings.IGNORE_SSL_ERRORS}
+      register: result
+      retries: 60
+      delay: 5
+      until: result.status == 200 or result.status == 403
+"""
+
+
+def wait_for_netbox() -> None:
+    """Wait for NetBox service to be ready."""
+    logger.info("Wait for NetBox service")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.NamedTemporaryFile(
+            mode="w+", suffix=".yml", delete=False
+        ) as temp_file:
+            temp_file.write(playbook_wait)
+
+        ansible_result = ansible_runner.run(
+            playbook=temp_file.name,
+            private_data_dir=temp_dir,
+            inventory=inventory,
+            cancel_callback=lambda: None,
+        )
+        if (
+            "localhost" in ansible_result.stats["failures"]
+            and ansible_result.stats["failures"]["localhost"] > 0
+        ):
+            logger.error("Failed to establish connection to netbox")
+            raise typer.Exit()
+
+
+def run_playbook(playbook_content: str, dryrun: bool = False) -> None:
+    """Run an Ansible playbook."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.NamedTemporaryFile(
+            mode="w+", suffix=".yml", delete=False
+        ) as temp_file:
+            temp_file.write(playbook_content)
+
+        if not dryrun:
+            ansible_runner.run(
+                playbook=temp_file.name,
+                private_data_dir=temp_dir,
+                inventory=inventory,
+                cancel_callback=lambda: None,
+            )

--- a/netbox_manager/resources.py
+++ b/netbox_manager/resources.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import concurrent.futures
+import glob
+from itertools import groupby
+import os
+from typing import Optional
+
+from jinja2 import Template
+from loguru import logger
+import yaml
+
+from .config import settings
+from .playbook import playbook_template, run_playbook
+
+
+def get_leading_number(file: str) -> str:
+    return file.split("-")[0]
+
+
+def handle_file(file: str, dryrun: bool) -> None:
+    template = Template(playbook_template)
+
+    template_vars = {}
+    template_tasks = []
+
+    logger.info(f"Handle file {file}")
+    with open(file) as fp:
+        data = yaml.safe_load(fp)
+        for rtask in data:
+            key, value = next(iter(rtask.items()))
+            if key == "vars":
+                template_vars = value
+            elif key == "debug":
+                task = {"ansible.builtin.debug": value}
+                template_tasks.append(task)
+            else:
+                state = "present"
+                if "state" in value:
+                    state = value["state"]
+                    del value["state"]
+
+                task = {
+                    "name": f"Manage NetBox resource {value.get('name', '')} of type {key}".replace(
+                        "  ", " "
+                    ),
+                    f"netbox.netbox.netbox_{key}": {
+                        "data": value,
+                        "state": state,
+                        "netbox_token": settings.TOKEN,
+                        "netbox_url": settings.URL,
+                        "validate_certs": not settings.IGNORE_SSL_ERRORS,
+                    },
+                }
+                template_tasks.append(task)
+
+    playbook_resources = template.render(
+        {
+            "name": os.path.basename(file),
+            "vars": yaml.dump(template_vars, indent=2, default_flow_style=False),
+            "tasks": yaml.dump(template_tasks, indent=2, default_flow_style=False),
+        }
+    )
+
+    if dryrun:
+        logger.info(f"Skip the execution of {file} as only one dry run")
+    else:
+        run_playbook(playbook_resources, dryrun)
+
+
+def process_resources(
+    files_changed: list[str],
+    always: bool,
+    limit: Optional[str],
+    parallel: int,
+    dryrun: bool,
+) -> None:
+    """Process NetBox resources."""
+    logger.info("Manage resources")
+
+    files = []
+    for extension in ["yml", "yaml"]:
+        try:
+            files.extend(glob.glob(os.path.join(settings.RESOURCES, f"*.{extension}")))
+        except FileNotFoundError:
+            logger.error(f"Could not load resources in {settings.RESOURCES}")
+
+    if not always:
+        files_filtered = [f for f in files if f in files_changed]
+    else:
+        files_filtered = files
+
+    files_filtered.sort(key=get_leading_number)
+    files_grouped = []
+    for _, group in groupby(files_filtered, key=get_leading_number):
+        files_grouped.append(list(group))
+
+    for group in files_grouped:  # type: ignore[assignment]
+        files_process = []
+        for file in group:
+            if limit and not os.path.basename(file).startswith(limit):
+                logger.info(f"Skipping {os.path.basename(file)}")
+                continue
+
+            files_process.append(file)
+
+        if files_process:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=parallel
+            ) as executor:
+                futures = [
+                    executor.submit(handle_file, file, dryrun) for file in files_process
+                ]
+                for future in concurrent.futures.as_completed(futures):
+                    future.result()

--- a/netbox_manager/utils.py
+++ b/netbox_manager/utils.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import git
+from loguru import logger
+import typer
+
+
+def get_changed_files(debug: bool = False) -> list[str]:
+    """Get list of changed files from Git repository."""
+    try:
+        config_repo = git.Repo(".")
+    except git.exc.InvalidGitRepositoryError:
+        logger.error(
+            "If only changed files are to be processed, the netbox-manager must be called in a Git repository."
+        )
+        raise typer.Exit()
+
+    commit = config_repo.head.commit
+    files_changed = [str(item.a_path) for item in commit.diff(commit.parents[0])]
+
+    if debug:
+        logger.debug(
+            "A list of the changed files follows. Only changed files are processed."
+        )
+        for f in files_changed:
+            logger.debug(f"- {f}")
+
+    return files_changed


### PR DESCRIPTION
Break down monolithic main.py into focused modules:
- config.py: settings, validation, and NetBox API setup
- cli.py: CLI callbacks and signal handlers
- playbook.py: Ansible playbook templates and execution
- resources.py: resource file processing logic
- utils.py: utility functions for Git operations

AI-assisted: Claude Code