### PR TITLE
Rename archive commands for consistency

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -450,9 +450,10 @@ def run_command(
 
 
 @app.command(
-    help="Export devicetypes, moduletypes, and resources to netbox-export.tar.gz"
+    name="export-archive",
+    help="Export devicetypes, moduletypes, and resources to netbox-export.tar.gz",
 )
-def export(
+def export_archive(
     image: bool = typer.Option(
         False,
         "--image",
@@ -548,8 +549,11 @@ def export(
         raise typer.Exit(1)
 
 
-@app.command(help="Import and sync content from a netbox-export.tar.gz file")
-def import_netbox(
+@app.command(
+    name="import-archive",
+    help="Import and sync content from a netbox-export.tar.gz file",
+)
+def import_archive(
     input_file: str = typer.Option(
         "netbox-export.tar.gz",
         "--input",


### PR DESCRIPTION
Rename import-netbox to import-archive and export to export-archive to better reflect their purpose and maintain naming consistency.

This change makes the command names more descriptive and aligns them with their functionality of handling archive files.

AI-assisted: Claude Code