### PR TITLE
Replace deprecated pkg_resources with importlib.metadata

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -2,9 +2,9 @@
 
 import concurrent.futures
 import glob
+from importlib import metadata
 from itertools import groupby
 import os
-import pkg_resources
 import platform
 import signal
 import subprocess
@@ -195,7 +195,7 @@ def init_logger(debug: bool = False) -> None:
 
 def callback_version(value: bool):
     if value:
-        print(f"Version {pkg_resources.get_distribution('netbox-manager').version}")
+        print(f"Version {metadata.version('netbox-manager')}")
         raise typer.Exit()
 
 


### PR DESCRIPTION
pkg_resources is deprecated and should be replaced with the standard library's importlib.metadata module, which is available since Python 3.8. This change updates the version retrieval in the callback_version function to use metadata.version() instead of pkg_resources.get_distribution().

AI-assisted: Claude Code