### PR TITLE
Add version command to display application version

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -619,6 +619,12 @@ def import_archive(
             raise typer.Exit(1)
 
 
+@app.command(name="version", help="Show version information")
+def version_command() -> None:
+    """Display version information for netbox-manager."""
+    print(f"netbox-manager {metadata.version('netbox-manager')}")
+
+
 @app.callback(invoke_without_command=True)
 def main_callback(ctx: typer.Context):
     """Handle default behavior when no command is specified."""


### PR DESCRIPTION
Add a dedicated `version` command to the CLI that displays the netbox-manager version. This provides a more intuitive way to check the version compared to the existing --version flag on the run command.

AI-assisted: Claude Code