### PR TITLE
Ensure .gitkeep files are never treated as manufacturers in DTL

### DIFF
--- a/netbox_manager/dtl.py
+++ b/netbox_manager/dtl.py
@@ -92,7 +92,17 @@ class Repo:
     def get_devices(self, vendors: Optional[list] = None):
         files = []
         discovered_vendors = []
-        vendor_dirs = os.listdir(self.get_devices_path())
+        devices_path = self.get_devices_path()
+
+        # Get all entries in the devices path
+        all_entries = os.listdir(devices_path)
+
+        # Filter to only include actual directories (not files like .gitkeep)
+        vendor_dirs = [
+            entry
+            for entry in all_entries
+            if os.path.isdir(os.path.join(devices_path, entry))
+        ]
 
         for folder in [
             vendor
@@ -104,9 +114,7 @@ class Repo:
             )
             for extension in self.yaml_extensions:
                 files.extend(
-                    glob.glob(
-                        os.path.join(self.get_devices_path(), folder, f"*.{extension}")
-                    )
+                    glob.glob(os.path.join(devices_path, folder, f"*.{extension}"))
                 )
         return files, discovered_vendors
 


### PR DESCRIPTION
- Filter devicetype entries to only include actual directories
- Use os.path.isdir() to validate manufacturer folders
- Prevents .gitkeep and other files from being processed as vendors

This change ensures that only valid manufacturer directories are discovered when scanning the devicetype library, avoiding potential issues with placeholder files like .gitkeep.

AI-assisted: Claude Code

Closes osism/netbox-manager#33