### PR TITLE
Add configuration to ignore specific resource files

### DIFF
--- a/netbox_manager/settings.toml.sample
+++ b/netbox_manager/settings.toml.sample
@@ -1,5 +1,6 @@
 DEVICETYPE_LIBRARY = "example/devicetypes"
 IGNORE_SSL_ERRORS = true
+IGNORED_FILES = ["000-external.yml", "000-external.yaml"]
 MODULETYPE_LIBRARY = "example/moduletypes"
 RESOURCES = "example/resources"
 TOKEN = ""


### PR DESCRIPTION
- Add IGNORED_FILES setting to control which resource files are skipped during processing
- Default ignores 000-external.yml and 000-external.yaml files
- Add --include-ignored-files CLI parameter to override ignoring behavior
- Update settings validation and sample configuration

AI-assisted: Claude Code