### PR TITLE
Exclude switch devices from autoconf interface analysis

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -821,119 +821,172 @@ def _generate_autoconf_tasks() -> list[dict]:
 
     logger.info("Analyzing NetBox data for automatic configuration...")
 
+    # Define switch roles to exclude from interface analysis
+    NETBOX_SWITCH_ROLES = [
+        "accessleaf",
+        "borderleaf",
+        "computeleaf",
+        "dataleaf",
+        "leaf",
+        "serviceleaf",
+        "spine",
+        "storageleaf",
+        "superspine",
+        "switch",
+        "transferleaf",
+    ]
+
+    # Get all devices first and filter out switches
+    logger.info("Filtering out switch devices...")
+    all_devices = netbox_api.dcim.devices.all()
+    non_switch_devices = {}
+
+    for device in all_devices:
+        if device.device_role and hasattr(device.device_role, "slug"):
+            device_role_slug = device.device_role.slug.lower()
+        elif device.device_role and hasattr(device.device_role, "name"):
+            device_role_slug = device.device_role.name.lower()
+        else:
+            device_role_slug = ""
+
+        if device_role_slug not in NETBOX_SWITCH_ROLES:
+            non_switch_devices[device.id] = device
+
+    logger.info(
+        f"Found {len(non_switch_devices)} non-switch devices out of {len(all_devices)} total devices"
+    )
+
     # 1. MAC address assignment for interfaces
     logger.info("Checking interfaces for MAC address assignments...")
-    interfaces = netbox_api.dcim.interfaces.all()
 
-    for interface in interfaces:
-        # Skip virtual interfaces
-        if (
-            interface.type
-            and hasattr(interface.type, "value")
-            and "virtual" in interface.type.value.lower()
-        ):
-            continue
-        if (
-            interface.type
-            and hasattr(interface.type, "label")
-            and "virtual" in interface.type.label.lower()
-        ):
-            continue
+    for device_id, device in non_switch_devices.items():
+        # Get interfaces for this specific device
+        device_interfaces = netbox_api.dcim.interfaces.filter(device_id=device_id)
 
-        # Get MAC addresses for this interface
-        mac_addresses = netbox_api.ipam.mac_addresses.filter(interface_id=interface.id)
+        for interface in device_interfaces:
+            # Skip virtual interfaces
+            if (
+                interface.type
+                and hasattr(interface.type, "value")
+                and "virtual" in interface.type.value.lower()
+            ):
+                continue
+            if (
+                interface.type
+                and hasattr(interface.type, "label")
+                and "virtual" in interface.type.label.lower()
+            ):
+                continue
 
-        # If interface has exactly one MAC address and no primary MAC, assign it
-        if len(mac_addresses) == 1 and not interface.mac_address:
-            mac_addr = mac_addresses[0]
-            tasks.append(
-                {
-                    "device_interface": {
-                        "device": interface.device.name,
-                        "name": interface.name,
-                        "primary_mac_address": mac_addr.address,
+            # Get MAC addresses for this interface
+            mac_addresses = netbox_api.ipam.mac_addresses.filter(
+                interface_id=interface.id
+            )
+
+            # If interface has exactly one MAC address and no primary MAC, assign it
+            if len(mac_addresses) == 1 and not interface.mac_address:
+                mac_addr = mac_addresses[0]
+                tasks.append(
+                    {
+                        "device_interface": {
+                            "device": device.name,
+                            "name": interface.name,
+                            "primary_mac_address": mac_addr.address,
+                        }
                     }
-                }
-            )
-            logger.debug(
-                f"Found MAC assignment: {interface.device.name}:{interface.name} -> {mac_addr.address}"
-            )
+                )
+                logger.debug(
+                    f"Found MAC assignment: {device.name}:{interface.name} -> {mac_addr.address}"
+                )
 
     # 2. OOB IP assignment from eth0 interfaces
     logger.info("Checking eth0 interfaces for OOB IP assignments...")
-    eth0_interfaces = netbox_api.dcim.interfaces.filter(name="eth0")
 
-    for interface in eth0_interfaces:
-        # Get IP addresses assigned to this interface
-        ip_addresses = netbox_api.ipam.ip_addresses.filter(
-            assigned_object_id=interface.id
+    for device_id, device in non_switch_devices.items():
+        # Get eth0 interface for this specific device
+        eth0_interfaces = netbox_api.dcim.interfaces.filter(
+            device_id=device_id, name="eth0"
         )
 
-        for ip_addr in ip_addresses:
-            device = netbox_api.dcim.devices.get(interface.device.id)
-            # If device doesn't have OOB IP set, assign this IP
-            if not device.oob_ip:
-                tasks.append(
-                    {"device": {"name": device.name, "oob_ip": ip_addr.address}}
-                )
-                logger.debug(
-                    f"Found OOB IP assignment: {device.name} -> {ip_addr.address}"
-                )
+        for interface in eth0_interfaces:
+            # Get IP addresses assigned to this interface
+            ip_addresses = netbox_api.ipam.ip_addresses.filter(
+                assigned_object_id=interface.id
+            )
+
+            for ip_addr in ip_addresses:
+                # If device doesn't have OOB IP set, assign this IP
+                if not device.oob_ip:
+                    tasks.append(
+                        {"device": {"name": device.name, "oob_ip": ip_addr.address}}
+                    )
+                    logger.debug(
+                        f"Found OOB IP assignment: {device.name} -> {ip_addr.address}"
+                    )
 
     # 3. Primary IPv4 assignment from Loopback0 interfaces
     logger.info("Checking Loopback0 interfaces for primary IPv4 assignments...")
-    loopback_interfaces = []
-    loopback_interfaces.extend(netbox_api.dcim.interfaces.filter(name="Loopback0"))
 
-    for interface in loopback_interfaces:
-        # Get IPv4 addresses assigned to this interface
-        ip_addresses = netbox_api.ipam.ip_addresses.filter(
-            assigned_object_id=interface.id
+    for device_id, device in non_switch_devices.items():
+        # Get Loopback0 interface for this specific device
+        loopback_interfaces = netbox_api.dcim.interfaces.filter(
+            device_id=device_id, name="Loopback0"
         )
 
-        for ip_addr in ip_addresses:
-            # Check if this is an IPv4 address
-            if ":" not in ip_addr.address:  # Simple IPv4 check
-                device = netbox_api.dcim.devices.get(interface.device.id)
-                # If device doesn't have primary IPv4 set, assign this IP
-                if not device.primary_ip4:
-                    tasks.append(
-                        {
-                            "device": {
-                                "name": device.name,
-                                "primary_ip4": ip_addr.address,
+        for interface in loopback_interfaces:
+            # Get IPv4 addresses assigned to this interface
+            ip_addresses = netbox_api.ipam.ip_addresses.filter(
+                assigned_object_id=interface.id
+            )
+
+            for ip_addr in ip_addresses:
+                # Check if this is an IPv4 address
+                if ":" not in ip_addr.address:  # Simple IPv4 check
+                    # If device doesn't have primary IPv4 set, assign this IP
+                    if not device.primary_ip4:
+                        tasks.append(
+                            {
+                                "device": {
+                                    "name": device.name,
+                                    "primary_ip4": ip_addr.address,
+                                }
                             }
-                        }
-                    )
-                    logger.debug(
-                        f"Found primary IPv4 assignment: {device.name} -> {ip_addr.address}"
-                    )
+                        )
+                        logger.debug(
+                            f"Found primary IPv4 assignment: {device.name} -> {ip_addr.address}"
+                        )
 
     # 4. Primary IPv6 assignment from Loopback0 interfaces
     logger.info("Checking Loopback0 interfaces for primary IPv6 assignments...")
-    for interface in loopback_interfaces:
-        # Get IPv6 addresses assigned to this interface
-        ip_addresses = netbox_api.ipam.ip_addresses.filter(
-            assigned_object_id=interface.id
+
+    for device_id, device in non_switch_devices.items():
+        # Get Loopback0 interface for this specific device
+        loopback_interfaces = netbox_api.dcim.interfaces.filter(
+            device_id=device_id, name="Loopback0"
         )
 
-        for ip_addr in ip_addresses:
-            # Check if this is an IPv6 address
-            if ":" in ip_addr.address:  # Simple IPv6 check
-                device = netbox_api.dcim.devices.get(interface.device.id)
-                # If device doesn't have primary IPv6 set, assign this IP
-                if not device.primary_ip6:
-                    tasks.append(
-                        {
-                            "device": {
-                                "name": device.name,
-                                "primary_ip6": ip_addr.address,
+        for interface in loopback_interfaces:
+            # Get IPv6 addresses assigned to this interface
+            ip_addresses = netbox_api.ipam.ip_addresses.filter(
+                assigned_object_id=interface.id
+            )
+
+            for ip_addr in ip_addresses:
+                # Check if this is an IPv6 address
+                if ":" in ip_addr.address:  # Simple IPv6 check
+                    # If device doesn't have primary IPv6 set, assign this IP
+                    if not device.primary_ip6:
+                        tasks.append(
+                            {
+                                "device": {
+                                    "name": device.name,
+                                    "primary_ip6": ip_addr.address,
+                                }
                             }
-                        }
-                    )
-                    logger.debug(
-                        f"Found primary IPv6 assignment: {device.name} -> {ip_addr.address}"
-                    )
+                        )
+                        logger.debug(
+                            f"Found primary IPv6 assignment: {device.name} -> {ip_addr.address}"
+                        )
 
     logger.info(f"Generated {len(tasks)} automatic configuration tasks")
     return tasks


### PR DESCRIPTION
- Add filter to exclude devices with switch roles from interface processing
- Define comprehensive list of switch roles (leaf, spine, switch, etc.)
- Change approach to iterate through filtered devices instead of all interfaces
- Improves performance by avoiding unnecessary switch interface analysis
- Focuses autoconf on non-network infrastructure devices only

AI-assisted: Claude Code