### PR TITLE
Fix interface API endpoint in purge command

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -1550,7 +1550,7 @@ def purge_command(
             ("dcim.cables", "cables"),
             ("dcim.mac_addresses", "MAC addresses"),
             # Device components
-            ("dcim.device_interfaces", "device interfaces"),
+            ("dcim.interfaces", "interfaces"),
             ("dcim.console_server_ports", "console server ports"),
             ("dcim.console_ports", "console ports"),
             ("dcim.power_outlets", "power outlets"),


### PR DESCRIPTION
Use 'dcim.interfaces' instead of 'dcim.device_interfaces' to match the correct NetBox API endpoint for interface resources.