### PR TITLE
Add virtual chassis to purge command resource list

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -1894,6 +1894,7 @@ def purge_command(
             ("dcim.device_types", "device types"),
             ("dcim.module_types", "module types"),
             # Virtualization resources (clusters depend on cluster types)
+            ("virtualization.virtual_chassis", "virtual chassis"),
             ("virtualization.clusters", "clusters"),
             ("virtualization.cluster_types", "cluster types"),
             # Network resources


### PR DESCRIPTION
Adds virtual_chassis to the purge command's resource deletion order to ensure proper cleanup of virtualization resources.

AI-assisted: Claude Code