### PR TITLE
Use community.general.yaml as stdout_callback for ansible-playbook

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -427,6 +427,7 @@ def handle_file(
                 inventory=inventory,
                 cancel_callback=lambda: None,
                 verbosity=verbosity,
+                envvars={"ANSIBLE_STDOUT_CALLBACK": "community.general.yaml"},
             )
             if fail_fast and result.status == "failed":
                 logger.error(
@@ -650,6 +651,7 @@ def _run_main(
                 private_data_dir=temp_dir,
                 inventory=inventory,
                 cancel_callback=lambda: None,
+                envvars={"ANSIBLE_STDOUT_CALLBACK": "community.general.yaml"},
             )
             if (
                 "localhost" in ansible_result.stats["failures"]


### PR DESCRIPTION
Configure ansible_runner to use the community.general.yaml stdout callback plugin for better formatted output in both resource processing and NetBox connection test playbooks.