### PR TITLE
Replace deprecated community.general.yaml callback with modern approach

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -427,7 +427,11 @@ def handle_file(
                 inventory=inventory,
                 cancel_callback=lambda: None,
                 verbosity=verbosity,
-                envvars={"ANSIBLE_STDOUT_CALLBACK": "community.general.yaml"},
+                envvars={
+                    "ANSIBLE_STDOUT_CALLBACK": "ansible.builtin.default",
+                    "ANSIBLE_CALLBACKS_ENABLED": "ansible.builtin.default",
+                    "ANSIBLE_STDOUT_CALLBACK_RESULT_FORMAT": "yaml",
+                },
             )
             if fail_fast and result.status == "failed":
                 logger.error(
@@ -651,7 +655,11 @@ def _run_main(
                 private_data_dir=temp_dir,
                 inventory=inventory,
                 cancel_callback=lambda: None,
-                envvars={"ANSIBLE_STDOUT_CALLBACK": "community.general.yaml"},
+                envvars={
+                    "ANSIBLE_STDOUT_CALLBACK": "ansible.builtin.default",
+                    "ANSIBLE_CALLBACKS_ENABLED": "ansible.builtin.default",
+                    "ANSIBLE_STDOUT_CALLBACK_RESULT_FORMAT": "yaml",
+                },
             )
             if (
                 "localhost" in ansible_result.stats["failures"]


### PR DESCRIPTION
The community.general.yaml callback plugin is deprecated and will be removed in community.general 12.0.0. This commit replaces it with the recommended approach using ansible.builtin.default callback with result_format=yaml.

- Replace ANSIBLE_STDOUT_CALLBACK from community.general.yaml to ansible.builtin.default
- Add ANSIBLE_CALLBACKS_ENABLED to enable the callback
- Add ANSIBLE_STDOUT_CALLBACK_RESULT_FORMAT=yaml for YAML output format

This maintains the same YAML output format while using the modern, non-deprecated callback mechanism available since ansible-core 2.13.

AI-assisted: Claude Code