### PR TITLE
Fix virtual_chassis module placement in purge command

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -1965,10 +1965,10 @@ def purge_command(
             ("dcim.inventory_items", "inventory items"),
             # Devices and infrastructure
             ("dcim.devices", "devices"),
+            ("dcim.virtual_chassis", "virtual chassis"),
             ("dcim.device_types", "device types"),
             ("dcim.module_types", "module types"),
             # Virtualization resources (clusters depend on cluster types)
-            ("virtualization.virtual_chassis", "virtual chassis"),
             ("virtualization.clusters", "clusters"),
             ("virtualization.cluster_types", "cluster types"),
             # Network resources


### PR DESCRIPTION
Move virtual_chassis from virtualization to dcim module where it belongs in NetBox's API structure. This ensures proper deletion order when purging resources.