### PR TITLE
Add Loopback0 validation to cluster IP generation

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -1498,6 +1498,14 @@ def _generate_cluster_loopback_tasks() -> Dict[str, List[Dict[str, Any]]]:
 
             # Generate IP addresses for each device
             for device in devices:
+                # Check if device should have a Loopback0 interface
+                if not should_have_loopback_interface(device):
+                    logger.debug(
+                        f"Skipping cluster loopback IP generation for {device.name} "
+                        f"(does not meet Loopback0 interface criteria)"
+                    )
+                    continue
+
                 ipv4_addr, ipv6_addr = calculate_loopback_ips(
                     device, ipv4_network, ipv6_network, loopback_offset_ipv4
                 )


### PR DESCRIPTION
Fixes issue where cluster-based loopback IP addresses were generated for all devices with cluster assignments, regardless of whether they should have Loopback0 interfaces according to the device role and sonic_parameters.hwsku validation rules.

The _generate_cluster_loopback_tasks() function now checks should_have_loopback_interface() before generating IP addresses, ensuring consistency with the Loopback0 interface creation logic.

AI-assisted: Claude Code