### PR TITLE
Fix MAC address extraction in autoconf interface assignments

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -1733,9 +1733,11 @@ def collect_interface_assignments(
             # Check if interface has a MAC address that should be set as primary
             mac_to_assign = None
             if interface.mac_address:
-                mac_to_assign = interface.mac_address
+                # interface.mac_address is typically already a string
+                mac_to_assign = str(interface.mac_address)
             elif interface.mac_addresses and not interface.mac_address:
-                mac_to_assign = interface.mac_addresses[0]
+                # interface.mac_addresses contains Record objects with mac_address attribute
+                mac_to_assign = str(interface.mac_addresses[0].mac_address)
 
             if mac_to_assign:
                 tasks.append(


### PR DESCRIPTION
The collect_interface_assignments function was assigning entire pynetbox Record objects to primary_mac_address instead of extracting the MAC address string. This caused the generated YAML to contain serialized Python objects rather than clean MAC address strings.

Changes:

- Convert interface.mac_address to string using str()
- Extract mac_address attribute from Record objects in mac_addresses list
- Add comments explaining the conversion logic

This ensures the generated 999-autoconf-device-interface.yml contains only MAC address strings like EC:F4:0C:8A:77:68 instead of the full Record object structure.

AI-assisted: Claude Code