### PR TITLE
Include switches in MAC address assignment for autoconf

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -1832,9 +1832,9 @@ def _generate_autoconf_tasks() -> Dict[str, List[Dict[str, Any]]]:
         f"({len(non_switch_devices)} non-switch, {len(all_devices_dict) - len(non_switch_devices)} switches)"
     )
 
-    # 1. MAC address assignment for interfaces (excludes switches)
-    logger.info("Collecting interface MAC assignments (excluding switches)...")
-    interface_tasks = collect_interface_assignments(netbox_api, non_switch_devices)
+    # 1. MAC address assignment for interfaces (includes all devices)
+    logger.info("Collecting interface MAC assignments (including switches)...")
+    interface_tasks = collect_interface_assignments(netbox_api, all_devices_dict)
     tasks_by_type["device_interface"].extend(interface_tasks)
 
     # 2. Consolidated device IP assignments (OOB, primary IPv4, primary IPv6)


### PR DESCRIPTION
Fix MAC address extraction in autoconf to include switches. Previously, the collect_interface_assignments function only processed non_switch_devices, which excluded switches from getting primary_mac_address assignments for their eth0 interfaces.

This change makes MAC address assignment consistent with OOB IP assignment, which already processes all devices including switches.

Changes:
- Update collect_interface_assignments call to use all_devices_dict instead of non_switch_devices
- Update comment and log message to reflect that switches are now included

AI-assisted: Claude Code