### PR TITLE
Add git commit info to export archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This file was started on November 24, 2025. Changes prior to this date are not included in the CHANGELOG.
+
+## [Unreleased]
+
+### Added
+- Export archive now includes COMMIT_INFO.txt with git commit hash, date, message, and branch information
+- Graceful handling when export is run outside a git repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ netbox-manager  # Process all resources
 netbox-manager --limit 300  # Process only files starting with 300
 netbox-manager --skipdtl  # Skip device type library
 netbox-manager export --output netbox-config.tar.gz  # Export configuration
+netbox-manager export-archive  # Export to netbox-export.tar.gz with git commit info
+netbox-manager export-archive --image  # Export to netbox-export.img (Linux only)
 
 # Linting and type checking
 flake8  # Uses .flake8 config (max line length: 200)


### PR DESCRIPTION
The export-archive command now includes a COMMIT_INFO.txt file in the generated tarball containing git commit hash, date, branch name, and commit message. This allows tracking which version of the configuration was used to create the export.

When run outside a git repository, the export continues without the commit info file and logs a warning message.

AI-assisted: Claude Code