### PR TITLE
Pin pipenv in CI via ensure-pipenv and regenerate lock

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7bed1768f23a5553fc70b152a2fd2022d2c99d2bae98b913c6b9fde008f6aa02"
+            "sha256": "c1a585bbb52017d128358fe081395c8c38dea62738335e0148c2c0b39eb0e11f"
         },
         "pipfile-spec": 6,
         "requires": {},

--- a/playbooks/pre.yml
+++ b/playbooks/pre.yml
@@ -2,12 +2,6 @@
 - name: Run preparations
   hosts: all
 
-  tasks:
-    - name: Install required packages
-      become: true
-      ansible.builtin.apt:
-        name:
-          - pipenv
-
   roles:
     - ensure-pip
+    - ensure-pipenv

--- a/playbooks/test-unit.yml
+++ b/playbooks/test-unit.yml
@@ -2,6 +2,9 @@
 - name: Run unit tests
   hosts: all
 
+  vars:
+    python_venv_dir: /tmp/venv
+
   tasks:
     - name: Install dependencies
       ansible.builtin.shell:
@@ -12,10 +15,8 @@
           set -o pipefail
           set -x
 
-          export PATH=$PATH:$HOME/.local/bin
-
-          pipenv install --dev --deploy
-          pipenv run pip install .
+          {{ python_venv_dir }}/bin/pipenv install --dev --deploy
+          {{ python_venv_dir }}/bin/pipenv run pip install .
 
     - name: Run pytest
       ansible.builtin.shell:
@@ -26,6 +27,4 @@
           set -o pipefail
           set -x
 
-          export PATH=$PATH:$HOME/.local/bin
-
-          pipenv run pytest
+          {{ python_venv_dir }}/bin/pipenv run pytest


### PR DESCRIPTION
## Summary

- Switches `pre.yml` to the `ensure-pipenv` role from osism/zuul-jobs
  (after `ensure-pip`), following the same pattern as other Python tool
  roles in that repo
- Pins pipenv to 2026.5.2 (renovate annotation in the role keeps it
  updated)
- Updates `test-unit.yml` to invoke pipenv as
  `{{ python_venv_dir }}/bin/pipenv` (`/tmp/bin/pipenv`)
- Regenerates `Pipfile.lock` with the pinned version to resolve the
  hash mismatch between Debian Bookworm's pipenv 2022.12.19 and current
  pipenv (2026.4.0 introduced PEP 503 name normalization before hashing)

## Dependency

Requires the `ensure-pipenv` role to be merged in osism/zuul-jobs first.

## Test plan

- [ ] Verify Zuul unit-test job passes with pinned pipenv
- [ ] Verify `pipenv install --dev --deploy` no longer reports stale lock locally

AI-assisted: Claude Code