### PR TITLE
Disambiguate duplicate interface labels on multi-homed nodes

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -1624,6 +1624,65 @@ def _generate_cluster_loopback_tasks() -> Dict[str, List[Dict[str, Any]]]:
     return tasks_by_type
 
 
+def _natural_sort_key(name: str) -> List[Any]:
+    """Build a numeric-aware sort key so e.g. 'Ethernet2' sorts before 'Ethernet10'."""
+    return [
+        int(part) if part.isdigit() else part.lower()
+        for part in re.split(r"(\d+)", name)
+    ]
+
+
+def _label_suffix(index: int) -> str:
+    """Map a zero-based index to a spreadsheet-style suffix: 0->a, 25->z, 26->aa."""
+    suffix = ""
+    index += 1
+    while index > 0:
+        index, remainder = divmod(index - 1, 26)
+        suffix = chr(ord("a") + remainder) + suffix
+    return suffix
+
+
+def _disambiguate_interface_labels(
+    tasks: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Append suffixes to duplicate interface labels on the same device.
+
+    A switch's ``device_interface_label`` (e.g. ``data1``) is applied to every
+    connected node interface. When a single node has multiple links carrying the
+    same label, the labels collide. This detects such duplicates per
+    ``(device, label)`` and renames them ``data1a``, ``data1b``, ... in natural
+    order of the node interface name. Labels that occur only once are left
+    unchanged, and tasks without a label are passed through untouched.
+    """
+    groups: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    for task in tasks:
+        interface = task.get("device_interface")
+        if not interface:
+            continue
+        label = interface.get("label")
+        if not label:
+            continue
+        key = (interface["device"], label)
+        groups.setdefault(key, []).append(interface)
+
+    for (device, label), interfaces in groups.items():
+        if len(interfaces) < 2:
+            continue
+
+        interfaces.sort(key=lambda iface: _natural_sort_key(iface["name"]))
+        renamed = []
+        for index, interface in enumerate(interfaces):
+            interface["label"] = f"{label}{_label_suffix(index)}"
+            renamed.append(interface["label"])
+
+        logger.info(
+            f"Disambiguated {len(interfaces)} duplicate '{label}' labels on "
+            f"{device}: {', '.join(renamed)}"
+        )
+
+    return tasks
+
+
 def _generate_device_interface_labels() -> List[Dict[str, Any]]:
     """Generate device interface label tasks based on switch, router, and firewall custom fields."""
     tasks = []
@@ -1740,6 +1799,7 @@ def _generate_device_interface_labels() -> List[Dict[str, Any]]:
                             f"Could not determine interface name for connection to {connected_device.name}"
                         )
 
+    tasks = _disambiguate_interface_labels(tasks)
     logger.info(f"Generated {len(tasks)} device interface label tasks")
     return tasks
 

--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -14,7 +14,7 @@ import sys
 import tarfile
 import tempfile
 import time
-from typing import Any, Optional, Tuple, Dict, List
+from typing import Any, Optional, Set, Tuple, Dict, List
 from typing_extensions import Annotated
 import warnings
 
@@ -1653,6 +1653,12 @@ def _disambiguate_interface_labels(
     ``(device, label)`` and renames them ``data1a``, ``data1b``, ... in natural
     order of the node interface name. Labels that occur only once are left
     unchanged, and tasks without a label are passed through untouched.
+
+    Generated suffixes are checked against every other label already present on
+    the same device, so a suffix can never re-introduce a duplicate by colliding
+    with an unrelated label. For example, if one switch labels a node ``data1``
+    twice and another switch labels the same node ``data1a`` once, the ``data1``
+    group skips the taken ``data1a`` and becomes ``data1b``, ``data1c``.
     """
     groups: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
     for task in tasks:
@@ -1665,15 +1671,31 @@ def _disambiguate_interface_labels(
         key = (interface["device"], label)
         groups.setdefault(key, []).append(interface)
 
+    # Per device, reserve every label that keeps its original value (labels that
+    # occur only once). Generated suffixes for the renamed groups must avoid
+    # these, and avoid each other, so disambiguation never recreates a duplicate.
+    reserved: Dict[str, Set[str]] = {}
+    for (device, label), interfaces in groups.items():
+        if len(interfaces) < 2:
+            reserved.setdefault(device, set()).add(label)
+
     for (device, label), interfaces in groups.items():
         if len(interfaces) < 2:
             continue
 
+        taken = reserved.setdefault(device, set())
         interfaces.sort(key=lambda iface: _natural_sort_key(iface["name"]))
         renamed = []
-        for index, interface in enumerate(interfaces):
-            interface["label"] = f"{label}{_label_suffix(index)}"
-            renamed.append(interface["label"])
+        index = 0
+        for interface in interfaces:
+            new_label = f"{label}{_label_suffix(index)}"
+            while new_label in taken:
+                index += 1
+                new_label = f"{label}{_label_suffix(index)}"
+            taken.add(new_label)
+            interface["label"] = new_label
+            renamed.append(new_label)
+            index += 1
 
         logger.info(
             f"Disambiguated {len(interfaces)} duplicate '{label}' labels on "

--- a/tests/unit/netbox_manager/test_interface_labels.py
+++ b/tests/unit/netbox_manager/test_interface_labels.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for disambiguation of duplicate device interface labels (issue #243).
+
+When a switch's ``device_interface_label`` (e.g. ``data1``) is applied to a node
+that has multiple links to that switch, the labels collide. The helper renames
+the duplicates ``data1a``, ``data1b``, ... in natural order of the node
+interface name.
+"""
+
+from netbox_manager import main
+
+
+def _task(device, name, label=None):
+    interface = {"device": device, "name": name, "tags": ["managed-by-osism"]}
+    if label is not None:
+        interface["label"] = label
+    return {"device_interface": interface}
+
+
+def _labels(tasks):
+    return [t["device_interface"].get("label") for t in tasks]
+
+
+def test_label_suffix_sequence():
+    assert main._label_suffix(0) == "a"
+    assert main._label_suffix(1) == "b"
+    assert main._label_suffix(25) == "z"
+    assert main._label_suffix(26) == "aa"
+    assert main._label_suffix(27) == "ab"
+
+
+def test_natural_sort_orders_numerically():
+    names = ["Ethernet10", "Ethernet2", "Ethernet1"]
+    assert sorted(names, key=main._natural_sort_key) == [
+        "Ethernet1",
+        "Ethernet2",
+        "Ethernet10",
+    ]
+
+
+def test_no_collision_leaves_labels_unchanged():
+    tasks = [
+        _task("node-0", "Ethernet3", "leaf1"),
+        _task("node-0", "Ethernet4", "leaf2"),
+    ]
+    main._disambiguate_interface_labels(tasks)
+    assert _labels(tasks) == ["leaf1", "leaf2"]
+
+
+def test_two_way_collision_uses_node_interface_order():
+    # Provided out of order; Ethernet3 must become 'a', Ethernet5 'b'.
+    tasks = [
+        _task("node-0", "Ethernet5", "data1"),
+        _task("node-0", "Ethernet3", "data1"),
+    ]
+    main._disambiguate_interface_labels(tasks)
+    by_name = {
+        t["device_interface"]["name"]: t["device_interface"]["label"] for t in tasks
+    }
+    assert by_name == {"Ethernet3": "data1a", "Ethernet5": "data1b"}
+
+
+def test_three_way_collision():
+    tasks = [
+        _task("node-0", "Ethernet3", "data1"),
+        _task("node-0", "Ethernet4", "data1"),
+        _task("node-0", "Ethernet5", "data1"),
+    ]
+    main._disambiguate_interface_labels(tasks)
+    assert _labels(tasks) == ["data1a", "data1b", "data1c"]
+
+
+def test_collisions_are_independent_per_device():
+    tasks = [
+        _task("node-0", "Ethernet3", "data1"),
+        _task("node-0", "Ethernet4", "data1"),
+        _task("node-1", "Ethernet3", "data1"),
+        _task("node-1", "Ethernet4", "data1"),
+    ]
+    main._disambiguate_interface_labels(tasks)
+    assert _labels(tasks) == ["data1a", "data1b", "data1a", "data1b"]
+
+
+def test_different_labels_on_same_device_do_not_collide():
+    tasks = [
+        _task("node-0", "Ethernet3", "data1"),
+        _task("node-0", "Ethernet4", "data2"),
+    ]
+    main._disambiguate_interface_labels(tasks)
+    assert _labels(tasks) == ["data1", "data2"]
+
+
+def test_natural_sort_assignment_with_double_digit_interface():
+    tasks = [
+        _task("node-0", "Ethernet10", "data1"),
+        _task("node-0", "Ethernet2", "data1"),
+    ]
+    main._disambiguate_interface_labels(tasks)
+    by_name = {
+        t["device_interface"]["name"]: t["device_interface"]["label"] for t in tasks
+    }
+    assert by_name == {"Ethernet2": "data1a", "Ethernet10": "data1b"}
+
+
+def test_tasks_without_label_are_untouched():
+    tasks = [
+        _task("node-0", "Ethernet0"),
+        _task("node-0", "Ethernet3", "data1"),
+        _task("node-0", "Ethernet4", "data1"),
+    ]
+    main._disambiguate_interface_labels(tasks)
+    assert _labels(tasks) == [None, "data1a", "data1b"]
+
+
+def test_overflow_beyond_26_links():
+    tasks = [_task("node-0", f"Ethernet{i:02d}", "data1") for i in range(27)]
+    main._disambiguate_interface_labels(tasks)
+    labels = _labels(tasks)
+    assert labels[0] == "data1a"
+    assert labels[25] == "data1z"
+    assert labels[26] == "data1aa"
+
+
+def test_returns_same_list_object():
+    tasks = [_task("node-0", "Ethernet3", "data1")]
+    assert main._disambiguate_interface_labels(tasks) is tasks

--- a/tests/unit/netbox_manager/test_interface_labels.py
+++ b/tests/unit/netbox_manager/test_interface_labels.py
@@ -125,3 +125,60 @@ def test_overflow_beyond_26_links():
 def test_returns_same_list_object():
     tasks = [_task("node-0", "Ethernet3", "data1")]
     assert main._disambiguate_interface_labels(tasks) is tasks
+
+
+def test_generated_suffix_skips_existing_singleton_label():
+    # Switch A labels node-0 'data1' twice; switch B labels node-0 'data1a' once.
+    # The singleton 'data1a' must survive, and the 'data1' group must skip it.
+    tasks = [
+        _task("node-0", "Ethernet3", "data1"),
+        _task("node-0", "Ethernet4", "data1"),
+        _task("node-0", "Ethernet5", "data1a"),
+    ]
+    main._disambiguate_interface_labels(tasks)
+    by_name = {
+        t["device_interface"]["name"]: t["device_interface"]["label"] for t in tasks
+    }
+    assert by_name == {
+        "Ethernet3": "data1b",
+        "Ethernet4": "data1c",
+        "Ethernet5": "data1a",
+    }
+    # No duplicate labels survive on the node.
+    labels = list(by_name.values())
+    assert len(labels) == len(set(labels))
+
+
+def test_generated_suffixes_do_not_collide_between_groups():
+    # 'data1' group would generate 'data1a'; an existing 'data1a' group would
+    # generate 'data1aa'. Neither set may overlap the other on the same node.
+    tasks = [
+        _task("node-0", "Ethernet3", "data1"),
+        _task("node-0", "Ethernet4", "data1"),
+        _task("node-0", "Ethernet5", "data1a"),
+        _task("node-0", "Ethernet6", "data1a"),
+    ]
+    main._disambiguate_interface_labels(tasks)
+    labels = _labels(tasks)
+    assert len(labels) == len(set(labels))
+
+
+def test_singleton_reservation_is_per_device():
+    # A singleton 'data1a' on node-1 must not push node-0's 'data1' group off 'a'.
+    tasks = [
+        _task("node-0", "Ethernet3", "data1"),
+        _task("node-0", "Ethernet4", "data1"),
+        _task("node-1", "Ethernet5", "data1a"),
+    ]
+    main._disambiguate_interface_labels(tasks)
+    by_dev_name = {
+        (t["device_interface"]["device"], t["device_interface"]["name"]): t[
+            "device_interface"
+        ]["label"]
+        for t in tasks
+    }
+    assert by_dev_name == {
+        ("node-0", "Ethernet3"): "data1a",
+        ("node-0", "Ethernet4"): "data1b",
+        ("node-1", "Ethernet5"): "data1a",
+    }


### PR DESCRIPTION
## Problem

`netbox-manager autoconf` propagates a switch's `device_interface_label` custom field (e.g. `data1`) onto every connected node interface. The label value comes from the **switch**, not the port, so it is applied identically to all node interfaces connected to that switch.

When a single server has **more than one link to the same switch**, both node interfaces receive the identical label `data1`, producing duplicate, ambiguous interface labels on that node.

## Fix

Detect duplicates per `(node device, label)` and disambiguate them by appending suffixes: `data1a`, `data1b`, ...

- **Ordering**: suffixes are assigned by natural sort of the node interface name (e.g. `Ethernet3` → `data1a`, `Ethernet5` → `data1b`).
- **Scope**: any two interfaces on the same node with the same label are disambiguated, regardless of source switch.
- Labels occurring only once are left unchanged (backward compatible — existing `leaf1`/`leaf2` topologies are untouched).
- Tasks without a label pass through untouched.

### Changes

- `netbox_manager/main.py`: three pure, side-effect-free helpers above `_generate_device_interface_labels()`:
  - `_natural_sort_key()` — numeric-aware sort (`Ethernet2` < `Ethernet10`)
  - `_label_suffix()` — index → `a, b, …, z, aa, ab, …` (robust beyond 26 links)
  - `_disambiguate_interface_labels()` — groups by `(device, label)`, renames duplicates, logs each renamed group
- `tests/unit/netbox_manager/test_interface_labels.py`: 11 unit tests for the pure helpers (no NetBox mocking required)

## Verification

- `flake8`: clean
- `mypy netbox_manager/`: no new errors
- `pytest tests/unit`: 14 passed

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)