### PR TITLE
Make segment interface label configurable

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -1705,8 +1705,49 @@ def _disambiguate_interface_labels(
     return tasks
 
 
+def _resolve_device_interface_label(
+    netbox_api: pynetbox.api,
+    device: Any,
+    segment_label_cache: Dict[int, Optional[str]],
+) -> Optional[str]:
+    """Resolve the interface label for a source device.
+
+    The per-device ``device_interface_label`` custom field takes precedence.
+    When it is not set, fall back to the ``_segment_device_interface_label`` key
+    of the device's segment (cluster) config context, retrieved via
+    ``_get_cluster_segment_config_context()``. Config contexts are fetched at
+    most once per cluster through ``segment_label_cache``. Returns ``None`` when
+    neither source provides a label.
+    """
+    if hasattr(device, "custom_fields") and device.custom_fields:
+        device_label = device.custom_fields.get("device_interface_label")
+        if device_label:
+            return device_label
+
+    cluster = getattr(device, "cluster", None)
+    if not cluster:
+        return None
+
+    cluster_id = cluster.id
+    if cluster_id not in segment_label_cache:
+        config_context = _get_cluster_segment_config_context(
+            netbox_api, cluster_id, getattr(cluster, "name", "")
+        )
+        segment_label_cache[cluster_id] = config_context.get(
+            "_segment_device_interface_label"
+        )
+
+    return segment_label_cache[cluster_id]
+
+
 def _generate_device_interface_labels() -> List[Dict[str, Any]]:
-    """Generate device interface label tasks based on switch, router, and firewall custom fields."""
+    """Generate device interface label tasks for switches, routers, and firewalls.
+
+    The interface label of a source device is taken from its
+    ``device_interface_label`` custom field, falling back to the
+    ``_segment_device_interface_label`` segment config context key when the
+    custom field is not set.
+    """
     tasks = []
     netbox_api = create_netbox_api()
 
@@ -1714,36 +1755,36 @@ def _generate_device_interface_labels() -> List[Dict[str, Any]]:
         "Analyzing switch, router, and firewall devices for device interface labeling..."
     )
 
-    # Get all devices and filter for switches, routers, and firewalls with device_interface_label custom field
+    # Get all devices and filter for switches, routers, and firewalls that have
+    # an interface label, either from the device_interface_label custom field or
+    # the segment-level _segment_device_interface_label config context.
     all_devices = netbox_api.dcim.devices.all()
     devices_with_labels = []
     switch_roles = get_switch_roles()
+    segment_label_cache: Dict[int, Optional[str]] = {}
 
     for device in all_devices:
         device_role_slug = get_device_role_slug(device)
 
-        # Check if device is a switch, router, or firewall with device_interface_label custom field
+        # Check if device is a switch, router, or firewall
         if device_role_slug in switch_roles or device_role_slug in [
             "router",
             "firewall",
         ]:
-            if hasattr(device, "custom_fields") and device.custom_fields:
-                device_interface_label = device.custom_fields.get(
-                    "device_interface_label"
+            label_value = _resolve_device_interface_label(
+                netbox_api, device, segment_label_cache
+            )
+            if label_value:
+                devices_with_labels.append((device, label_value))
+                device_type_name = (
+                    "switch" if device_role_slug in switch_roles else device_role_slug
                 )
-                if device_interface_label:
-                    devices_with_labels.append((device, device_interface_label))
-                    device_type_name = (
-                        "switch"
-                        if device_role_slug in switch_roles
-                        else device_role_slug
-                    )
-                    logger.debug(
-                        f"Found {device_type_name} {device.name} with device_interface_label: {device_interface_label}"
-                    )
+                logger.debug(
+                    f"Found {device_type_name} {device.name} with interface label: {label_value}"
+                )
 
     logger.info(
-        f"Found {len(devices_with_labels)} devices (switches/routers/firewalls) with device_interface_label custom field"
+        f"Found {len(devices_with_labels)} devices (switches/routers/firewalls) with an interface label"
     )
 
     # Process each device with device_interface_label
@@ -2580,7 +2621,7 @@ def autoconf_command(
 
     1. Create Loopback0 interfaces for switches and devices with specific roles
     2. Generate cluster-based loopback IP addresses for devices with assigned clusters
-    3. Set interface labels on connected node devices based on switch device_interface_label custom field
+    3. Set interface labels on connected node devices based on the device_interface_label custom field or the _segment_device_interface_label segment config context
     4. Assign primary MAC addresses to interfaces that have exactly one MAC
     5. Assign OOB IP addresses from eth0 interfaces to devices
     6. Assign primary IPv4 addresses from Loopback0 interfaces to devices

--- a/tests/unit/netbox_manager/test_segment_interface_label.py
+++ b/tests/unit/netbox_manager/test_segment_interface_label.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for segment-level device interface label resolution (issue #220).
+
+The interface label of a source device (switch/router/firewall) comes from its
+``device_interface_label`` custom field, falling back to the
+``_segment_device_interface_label`` segment config context key when the custom
+field is not set. The per-device custom field always wins.
+"""
+
+from types import SimpleNamespace
+
+from netbox_manager import main
+
+
+def _device(custom_fields=None, cluster=None):
+    return SimpleNamespace(
+        name="source-device",
+        custom_fields={} if custom_fields is None else custom_fields,
+        cluster=cluster,
+    )
+
+
+def _cluster(cluster_id=1, name="segment-a"):
+    return SimpleNamespace(id=cluster_id, name=name)
+
+
+def test_custom_field_takes_precedence_over_segment(mocker):
+    segment = mocker.patch.object(
+        main,
+        "_get_cluster_segment_config_context",
+        return_value={"_segment_device_interface_label": "segment-label"},
+    )
+    device = _device(
+        custom_fields={"device_interface_label": "device-label"},
+        cluster=_cluster(),
+    )
+
+    assert main._resolve_device_interface_label(None, device, {}) == "device-label"
+    segment.assert_not_called()
+
+
+def test_falls_back_to_segment_when_custom_field_unset(mocker):
+    mocker.patch.object(
+        main,
+        "_get_cluster_segment_config_context",
+        return_value={"_segment_device_interface_label": "segment-label"},
+    )
+    device = _device(custom_fields={}, cluster=_cluster())
+
+    assert main._resolve_device_interface_label(None, device, {}) == "segment-label"
+
+
+def test_empty_custom_field_falls_back_to_segment(mocker):
+    mocker.patch.object(
+        main,
+        "_get_cluster_segment_config_context",
+        return_value={"_segment_device_interface_label": "segment-label"},
+    )
+    device = _device(
+        custom_fields={"device_interface_label": ""},
+        cluster=_cluster(),
+    )
+
+    assert main._resolve_device_interface_label(None, device, {}) == "segment-label"
+
+
+def test_returns_none_when_neither_source_set(mocker):
+    mocker.patch.object(
+        main,
+        "_get_cluster_segment_config_context",
+        return_value={},
+    )
+    device = _device(custom_fields={}, cluster=_cluster())
+
+    assert main._resolve_device_interface_label(None, device, {}) is None
+
+
+def test_custom_field_used_when_device_has_no_cluster(mocker):
+    segment = mocker.patch.object(main, "_get_cluster_segment_config_context")
+    device = _device(
+        custom_fields={"device_interface_label": "device-label"},
+        cluster=None,
+    )
+
+    assert main._resolve_device_interface_label(None, device, {}) == "device-label"
+    segment.assert_not_called()
+
+
+def test_no_segment_lookup_when_device_has_no_cluster(mocker):
+    segment = mocker.patch.object(main, "_get_cluster_segment_config_context")
+    device = _device(custom_fields={}, cluster=None)
+
+    assert main._resolve_device_interface_label(None, device, {}) is None
+    segment.assert_not_called()
+
+
+def test_segment_context_is_fetched_once_per_cluster(mocker):
+    segment = mocker.patch.object(
+        main,
+        "_get_cluster_segment_config_context",
+        return_value={"_segment_device_interface_label": "segment-label"},
+    )
+    cluster = _cluster(cluster_id=7)
+    cache: dict = {}
+    first = _device(custom_fields={}, cluster=cluster)
+    second = _device(custom_fields={}, cluster=cluster)
+
+    assert main._resolve_device_interface_label(None, first, cache) == "segment-label"
+    assert main._resolve_device_interface_label(None, second, cache) == "segment-label"
+    segment.assert_called_once()
+
+
+def test_absent_segment_label_is_cached(mocker):
+    segment = mocker.patch.object(
+        main,
+        "_get_cluster_segment_config_context",
+        return_value={},
+    )
+    cluster = _cluster(cluster_id=9)
+    cache: dict = {}
+    first = _device(custom_fields={}, cluster=cluster)
+    second = _device(custom_fields={}, cluster=cluster)
+
+    assert main._resolve_device_interface_label(None, first, cache) is None
+    assert main._resolve_device_interface_label(None, second, cache) is None
+    segment.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #220.

Make the device interface label configurable on the **segment level** via the
new segment config context key `_segment_device_interface_label`, in addition to
the existing per-device `device_interface_label` custom field. The label no
longer has to be set on every source device individually when a whole segment
should share one label.

The per-device custom field keeps **precedence**: the segment-level value is used
only as a fallback when `device_interface_label` is not set on the device. The
change is purely additive — setups that do not define the new key keep their
current behavior.

## Change set (in commit order)

1. **Add segment-level device interface label fallback**
   - New helper `_resolve_device_interface_label(netbox_api, device, segment_label_cache)`
     in `netbox_manager/main.py`. It returns the device's `device_interface_label`
     custom field when set, otherwise falls back to the
     `_segment_device_interface_label` key of the device's segment (cluster)
     config context, read via the existing `_get_cluster_segment_config_context()`
     — the same mechanism already used for the `_segment_loopback_*` parameters
     (#166). Config contexts are fetched at most once per cluster via a small
     per-run cache.
   - `_generate_device_interface_labels()` now resolves the label through this
     helper for every participating source device (switch/router/firewall),
     independent of which of those roles it has.
   - Updated the `autoconf` command docstring to mention the new source.
   - Unit tests in `tests/unit/netbox_manager/test_segment_interface_label.py`
     cover precedence, empty-custom-field fallback, the no-label and no-cluster
     paths, and per-cluster caching (including caching of an absent key).

2. **Document `_segment_device_interface_label` in changelog**
   - New `Unreleased` → `Added` entry in `CHANGELOG.md`.

## How precedence is resolved

| Device `device_interface_label` | Segment `_segment_device_interface_label` | Result |
|---|---|---|
| set | (any) | device value |
| unset | set | segment value |
| unset | unset / no cluster | no label (unchanged behavior) |

## Verification

- `pytest tests/unit` — 11 passed
- `flake8 netbox_manager/ tests/` — clean
- `black --check netbox_manager/ tests/` — clean
- `mypy netbox_manager/` — no new errors (only the pre-existing third-party
  `import-untyped` warnings present on `main`)

## Notes for reviewers

- Tests mock only `_get_cluster_segment_config_context` (the NetBox I/O
  boundary) and exercise the pure resolution logic, consistent with the
  deferral of full pynetbox fixtures to #232.
- `example/` is gilt-overlaid from `osism/testbed` and was intentionally left
  untouched; config contexts are not represented in those resource files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
