### PR TITLE
Add Tier 1 unit tests for pure-logic helpers in main.py

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -2449,18 +2449,6 @@ def _filter_tasks_by_type_by_device(
     return filtered
 
 
-def _filter_portchannel_tasks_by_device(
-    tasks: List[Dict[str, Any]], device_filter: set
-) -> List[Dict[str, Any]]:
-    """Filter portchannel tasks, keeping a pair if either device matches."""
-    filtered = []
-    for task in tasks:
-        names = _extract_device_names_from_autoconf_task(task)
-        if any(name in device_filter for name in names):
-            filtered.append(task)
-    return filtered
-
-
 def _run_autoconf_for_devices(
     device_filter: Optional[set],
     output_dir: str,
@@ -2532,7 +2520,10 @@ def _run_autoconf_for_devices(
         cluster_loopback_tasks = _filter_tasks_by_type_by_device(
             cluster_loopback_tasks, device_filter
         )
-        portchannel_tasks_list = _filter_portchannel_tasks_by_device(
+        # PortChannel generation only emits single-device `device_interface`
+        # tasks (LAG creations + member assignments), so the generic per-task
+        # device filter is sufficient -- there is no two-device "pair" to keep.
+        portchannel_tasks_list = _filter_tasks_by_device(
             portchannel_tasks_list, device_filter
         )
         other_tasks = _filter_tasks_by_type_by_device(other_tasks, device_filter)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,16 @@ os.environ.setdefault("NETBOX_MANAGER_URL", "http://localhost:8000")
 os.environ.setdefault("NETBOX_MANAGER_TOKEN", "test-token")
 os.environ.setdefault("NETBOX_MANAGER_IGNORE_SSL_ERRORS", "false")
 
+# Keep the role helpers hermetic. A real deployment env may export
+# `NETBOX_MANAGER_NODE_ROLES` / `..._SWITCH_ROLES`, which dynaconf would load as
+# `settings.NODE_ROLES` / `settings.SWITCH_ROLES` and make `get_node_roles()` /
+# `get_switch_roles()` return the deployment list -- breaking the default-role
+# and `is _DEFAULT_*` assertions. Drop them before `netbox_manager.main` is
+# imported so the in-module defaults are the baseline; tests that need an
+# override set it explicitly via `monkeypatch.setattr(main.settings, ...)`.
+os.environ.pop("NETBOX_MANAGER_NODE_ROLES", None)
+os.environ.pop("NETBOX_MANAGER_SWITCH_ROLES", None)
+
 # Heavier per-module fixtures -- full `pynetbox.api` clients, mocked
 # `ansible_runner.run`, `git.Repo`, `subprocess` -- belong to the later #232
 # tiers. Tier 1 (#247) only needs the lightweight attribute-bag factories below.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,98 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+from types import SimpleNamespace
+
+import pytest
+
 # Set dynaconf env vars before any test imports `netbox_manager.main`, since
 # `Dynaconf(...)` and the validator registration run at import time. Defaults
 # are used so tests do not depend on a real `settings.toml` being present.
-import os
-
 os.environ.setdefault("NETBOX_MANAGER_URL", "http://localhost:8000")
 os.environ.setdefault("NETBOX_MANAGER_TOKEN", "test-token")
 os.environ.setdefault("NETBOX_MANAGER_IGNORE_SSL_ERRORS", "false")
 
-# Per-module fixtures (mock pynetbox device / interface / IP / VRF / cluster /
-# config-context / prefix shapes; mocked `ansible_runner.run`; `git.Repo`;
-# `subprocess.run` / `check_call`) are added by the per-module sub-issues
-# tracked in #232.
+# Heavier per-module fixtures -- full `pynetbox.api` clients, mocked
+# `ansible_runner.run`, `git.Repo`, `subprocess` -- belong to the later #232
+# tiers. Tier 1 (#247) only needs the lightweight attribute-bag factories below.
+
+
+@pytest.fixture
+def make_device():
+    """Build device-like attribute bags for the pure-logic helpers.
+
+    Returns a factory producing a :class:`types.SimpleNamespace` that exposes
+    only the attributes the helpers in :mod:`netbox_manager.main` read from a
+    pynetbox device -- ``name``, ``role`` (with ``slug`` / ``name``),
+    ``device_type`` (with ``model``) and ``custom_fields``. No live NetBox or
+    full ``pynetbox`` mock is involved.
+
+    Keyword arguments of the factory:
+        name: Device name.
+        role_slug / role_name: Attributes for ``device.role``; when both are
+            omitted ``device.role`` is ``None`` (an unset role).
+        device_type_model: ``model`` for ``device.device_type``; when omitted
+            ``device.device_type`` is ``None``.
+        custom_fields: Mapping for ``device.custom_fields`` (defaults to ``{}``).
+
+    Shared with later #232 test tiers; extend it here rather than re-deriving
+    device shapes per test module.
+    """
+
+    def _make_device(
+        *,
+        name="test-device",
+        role_slug=None,
+        role_name=None,
+        device_type_model=None,
+        custom_fields=None,
+    ):
+        if role_slug is None and role_name is None:
+            role = None
+        else:
+            role = SimpleNamespace()
+            if role_slug is not None:
+                role.slug = role_slug
+            if role_name is not None:
+                role.name = role_name
+
+        device_type = (
+            SimpleNamespace(model=device_type_model)
+            if device_type_model is not None
+            else None
+        )
+
+        return SimpleNamespace(
+            name=name,
+            role=role,
+            device_type=device_type,
+            custom_fields={} if custom_fields is None else custom_fields,
+        )
+
+    return _make_device
+
+
+@pytest.fixture
+def make_interface():
+    """Build interface-like attribute bags for the pure-logic helpers.
+
+    Returns a factory producing a :class:`types.SimpleNamespace` that exposes
+    only ``type`` (with ``value`` / ``label``), which is all
+    :func:`netbox_manager.main.is_virtual_interface` reads. When neither
+    ``type_value`` nor ``type_label`` is given, ``type`` is ``None``.
+
+    Shared with later #232 test tiers.
+    """
+
+    def _make_interface(*, type_value=None, type_label=None):
+        if type_value is None and type_label is None:
+            interface_type = None
+        else:
+            interface_type = SimpleNamespace()
+            if type_value is not None:
+                interface_type.value = type_value
+            if type_label is not None:
+                interface_type.label = type_label
+        return SimpleNamespace(type=interface_type)
+
+    return _make_interface

--- a/tests/unit/netbox_manager/test_autoconf_helpers.py
+++ b/tests/unit/netbox_manager/test_autoconf_helpers.py
@@ -69,6 +69,22 @@ class TestFilterTasksByDevice:
         tasks = [{"device_interface": {"device": "node-0"}}]
         assert main._filter_tasks_by_device(tasks, {"switch-9"}) == []
 
+    def test_keeps_matching_portchannel_lag_tasks(self):
+        # The shapes `_generate_portchannel_tasks` actually emits: per-switch LAG
+        # creations and member assignments, each a single-device
+        # `device_interface` task. The pre-consolidation
+        # `_filter_portchannel_tasks_by_device` ran on exactly this list.
+        tasks = [
+            {"device_interface": {"device": "switch-1", "name": "PortChannel3", "type": "lag"}},
+            {"device_interface": {"device": "switch-2", "name": "PortChannel3", "type": "lag"}},
+            {"device_interface": {"device": "switch-1", "name": "Ethernet3", "lag": "PortChannel3"}},
+            {"device_interface": {"device": "switch-2", "name": "Ethernet3", "lag": "PortChannel3"}},
+        ]
+        assert main._filter_tasks_by_device(tasks, {"switch-1"}) == [
+            {"device_interface": {"device": "switch-1", "name": "PortChannel3", "type": "lag"}},
+            {"device_interface": {"device": "switch-1", "name": "Ethernet3", "lag": "PortChannel3"}},
+        ]
+
 
 class TestFilterTasksByTypeByDevice:
     """``_filter_tasks_by_type_by_device`` filters each resource-type bucket."""
@@ -87,30 +103,3 @@ class TestFilterTasksByTypeByDevice:
             # The bucket key is preserved even when nothing matches.
             "cable": [],
         }
-
-
-class TestFilterPortchannelTasksByDevice:
-    """``_filter_portchannel_tasks_by_device`` keeps a pair if either matches."""
-
-    def test_keeps_task_when_either_device_matches(self):
-        tasks = [
-            {
-                "cable": {
-                    "termination_a": {"device": "switch-1"},
-                    "termination_b": {"device": "switch-2"},
-                }
-            },
-            {"device_interface": {"device": "switch-9"}},
-        ]
-        assert main._filter_portchannel_tasks_by_device(tasks, {"switch-2"}) == [
-            {
-                "cable": {
-                    "termination_a": {"device": "switch-1"},
-                    "termination_b": {"device": "switch-2"},
-                }
-            }
-        ]
-
-    def test_empty_filter_keeps_nothing(self):
-        tasks = [{"device_interface": {"device": "switch-1"}}]
-        assert main._filter_portchannel_tasks_by_device(tasks, set()) == []

--- a/tests/unit/netbox_manager/test_autoconf_helpers.py
+++ b/tests/unit/netbox_manager/test_autoconf_helpers.py
@@ -75,14 +75,50 @@ class TestFilterTasksByDevice:
         # `device_interface` task. The pre-consolidation
         # `_filter_portchannel_tasks_by_device` ran on exactly this list.
         tasks = [
-            {"device_interface": {"device": "switch-1", "name": "PortChannel3", "type": "lag"}},
-            {"device_interface": {"device": "switch-2", "name": "PortChannel3", "type": "lag"}},
-            {"device_interface": {"device": "switch-1", "name": "Ethernet3", "lag": "PortChannel3"}},
-            {"device_interface": {"device": "switch-2", "name": "Ethernet3", "lag": "PortChannel3"}},
+            {
+                "device_interface": {
+                    "device": "switch-1",
+                    "name": "PortChannel3",
+                    "type": "lag",
+                }
+            },
+            {
+                "device_interface": {
+                    "device": "switch-2",
+                    "name": "PortChannel3",
+                    "type": "lag",
+                }
+            },
+            {
+                "device_interface": {
+                    "device": "switch-1",
+                    "name": "Ethernet3",
+                    "lag": "PortChannel3",
+                }
+            },
+            {
+                "device_interface": {
+                    "device": "switch-2",
+                    "name": "Ethernet3",
+                    "lag": "PortChannel3",
+                }
+            },
         ]
         assert main._filter_tasks_by_device(tasks, {"switch-1"}) == [
-            {"device_interface": {"device": "switch-1", "name": "PortChannel3", "type": "lag"}},
-            {"device_interface": {"device": "switch-1", "name": "Ethernet3", "lag": "PortChannel3"}},
+            {
+                "device_interface": {
+                    "device": "switch-1",
+                    "name": "PortChannel3",
+                    "type": "lag",
+                }
+            },
+            {
+                "device_interface": {
+                    "device": "switch-1",
+                    "name": "Ethernet3",
+                    "lag": "PortChannel3",
+                }
+            },
         ]
 
 

--- a/tests/unit/netbox_manager/test_autoconf_helpers.py
+++ b/tests/unit/netbox_manager/test_autoconf_helpers.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the autoconf helpers in ``netbox_manager.main`` (issue #247).
+
+Covers group 4 of the Tier 1 scope tracked in #232: deriving the autoconf file
+prefix from a site folder name, extracting device names from autoconf tasks,
+and the device-filter helpers. All operate on plain dicts/lists and sets.
+"""
+
+from netbox_manager import main
+
+
+class TestGetAutoconfPrefix:
+    """``get_autoconf_prefix`` maps a folder number to its hundred-range x99."""
+
+    def test_two_hundred_range(self):
+        assert main.get_autoconf_prefix("200-aa") == "299-autoconf"
+
+    def test_thousand_range(self):
+        assert main.get_autoconf_prefix("1000-xx") == "1099-autoconf"
+
+    def test_zero_range(self):
+        assert main.get_autoconf_prefix("0-x") == "99-autoconf"
+
+    def test_floors_to_start_of_hundred_range(self):
+        # 250 -> 200 -> 299; the part inside the range does not matter.
+        assert main.get_autoconf_prefix("250-foo") == "299-autoconf"
+
+
+class TestExtractDeviceNamesFromAutoconfTask:
+    """``_extract_device_names_from_autoconf_task`` finds refs and definitions."""
+
+    def test_nested_device_reference(self):
+        task = {"device_interface": {"device": "node-0", "name": "Ethernet0"}}
+        assert main._extract_device_names_from_autoconf_task(task) == ["node-0"]
+
+    def test_device_definition_task(self):
+        task = {"device": {"name": "node-0", "site": "Discworld"}}
+        assert main._extract_device_names_from_autoconf_task(task) == ["node-0"]
+
+    def test_top_level_string_device_reference(self):
+        assert main._extract_device_names_from_autoconf_task({"device": "node-0"}) == [
+            "node-0"
+        ]
+
+    def test_no_device_returns_empty(self):
+        assert (
+            main._extract_device_names_from_autoconf_task({"vlan": {"vid": 100}}) == []
+        )
+
+
+class TestFilterTasksByDevice:
+    """``_filter_tasks_by_device`` keeps tasks referencing a filtered device."""
+
+    def test_keeps_only_matching_tasks(self):
+        tasks = [
+            {"device_interface": {"device": "node-0"}},
+            {"device_interface": {"device": "node-1"}},
+        ]
+        assert main._filter_tasks_by_device(tasks, {"node-0"}) == [
+            {"device_interface": {"device": "node-0"}}
+        ]
+
+    def test_empty_filter_keeps_nothing(self):
+        tasks = [{"device_interface": {"device": "node-0"}}]
+        assert main._filter_tasks_by_device(tasks, set()) == []
+
+    def test_no_match_keeps_nothing(self):
+        tasks = [{"device_interface": {"device": "node-0"}}]
+        assert main._filter_tasks_by_device(tasks, {"switch-9"}) == []
+
+
+class TestFilterTasksByTypeByDevice:
+    """``_filter_tasks_by_type_by_device`` filters each resource-type bucket."""
+
+    def test_filters_within_each_bucket_and_keeps_keys(self):
+        tasks_by_type = {
+            "device_interface": [
+                {"device_interface": {"device": "node-0"}},
+                {"device_interface": {"device": "node-1"}},
+            ],
+            "cable": [{"cable": {"termination_a": {"device": "node-9"}}}],
+        }
+        result = main._filter_tasks_by_type_by_device(tasks_by_type, {"node-0"})
+        assert result == {
+            "device_interface": [{"device_interface": {"device": "node-0"}}],
+            # The bucket key is preserved even when nothing matches.
+            "cable": [],
+        }
+
+
+class TestFilterPortchannelTasksByDevice:
+    """``_filter_portchannel_tasks_by_device`` keeps a pair if either matches."""
+
+    def test_keeps_task_when_either_device_matches(self):
+        tasks = [
+            {
+                "cable": {
+                    "termination_a": {"device": "switch-1"},
+                    "termination_b": {"device": "switch-2"},
+                }
+            },
+            {"device_interface": {"device": "switch-9"}},
+        ]
+        assert main._filter_portchannel_tasks_by_device(tasks, {"switch-2"}) == [
+            {
+                "cable": {
+                    "termination_a": {"device": "switch-1"},
+                    "termination_b": {"device": "switch-2"},
+                }
+            }
+        ]
+
+    def test_empty_filter_keeps_nothing(self):
+        tasks = [{"device_interface": {"device": "switch-1"}}]
+        assert main._filter_portchannel_tasks_by_device(tasks, set()) == []

--- a/tests/unit/netbox_manager/test_helpers.py
+++ b/tests/unit/netbox_manager/test_helpers.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the pure-logic helpers in ``netbox_manager.main`` (issue #247).
+
+Covers the settings/role helpers (group 1) and the generic
+data-transformation helpers (group 2) of the Tier 1 scope tracked in #232.
+These functions are deterministic transformations of plain Python data or of
+tiny attribute-bag objects, so they need no live NetBox, ``ansible_runner`` or
+filesystem -- at most a ``types.SimpleNamespace`` or one of the shared
+``make_device`` / ``make_interface`` factories from ``conftest.py``.
+"""
+
+from types import SimpleNamespace
+
+from netbox_manager import main
+
+
+class TestGetNodeRoles:
+    """``get_node_roles`` reads ``settings.NODE_ROLES`` or falls back."""
+
+    def test_returns_setting_when_present(self, monkeypatch):
+        monkeypatch.setattr(main.settings, "NODE_ROLES", ["custom-node"], raising=False)
+        assert main.get_node_roles() == ["custom-node"]
+
+    def test_falls_back_to_default_when_absent(self):
+        # The conftest stub never sets NODE_ROLES, so this is the natural state.
+        assert main.get_node_roles() is main._DEFAULT_NODE_ROLES
+
+    def test_falls_back_to_default_when_none(self, monkeypatch):
+        monkeypatch.setattr(main.settings, "NODE_ROLES", None, raising=False)
+        assert main.get_node_roles() is main._DEFAULT_NODE_ROLES
+
+    def test_falls_back_to_default_when_empty_list(self, monkeypatch):
+        # Empty list is falsy, so the ``or`` falls through to the default.
+        monkeypatch.setattr(main.settings, "NODE_ROLES", [], raising=False)
+        assert main.get_node_roles() is main._DEFAULT_NODE_ROLES
+
+
+class TestGetSwitchRoles:
+    """``get_switch_roles`` mirrors ``get_node_roles`` for SWITCH_ROLES."""
+
+    def test_returns_setting_when_present(self, monkeypatch):
+        monkeypatch.setattr(
+            main.settings, "SWITCH_ROLES", ["custom-switch"], raising=False
+        )
+        assert main.get_switch_roles() == ["custom-switch"]
+
+    def test_falls_back_to_default_when_absent(self):
+        assert main.get_switch_roles() is main._DEFAULT_SWITCH_ROLES
+
+    def test_falls_back_to_default_when_none(self, monkeypatch):
+        monkeypatch.setattr(main.settings, "SWITCH_ROLES", None, raising=False)
+        assert main.get_switch_roles() is main._DEFAULT_SWITCH_ROLES
+
+    def test_falls_back_to_default_when_empty_list(self, monkeypatch):
+        monkeypatch.setattr(main.settings, "SWITCH_ROLES", [], raising=False)
+        assert main.get_switch_roles() is main._DEFAULT_SWITCH_ROLES
+
+
+class TestGetLeadingNumber:
+    """``get_leading_number`` returns ``basename.split('-')[0]``."""
+
+    def test_extracts_leading_number(self):
+        assert main.get_leading_number("300-devices.yml") == "300"
+
+    def test_strips_path_to_basename_first(self):
+        assert main.get_leading_number("/abs/path/300-devices.yml") == "300"
+
+    def test_no_dash_returns_whole_basename(self):
+        assert main.get_leading_number("noprefix.yml") == "noprefix.yml"
+
+    def test_no_dash_with_path_returns_basename_only(self):
+        assert main.get_leading_number("/abs/path/noprefix.yml") == "noprefix.yml"
+
+
+class TestDeepMerge:
+    """``deep_merge`` recursively merges with dict2 winning conflicts."""
+
+    def test_recursive_merge_of_nested_dicts(self):
+        merged = main.deep_merge(
+            {"a": 1, "nested": {"x": 1, "shared": "old"}},
+            {"b": 2, "nested": {"y": 2, "shared": "new"}},
+        )
+        assert merged == {
+            "a": 1,
+            "b": 2,
+            "nested": {"x": 1, "y": 2, "shared": "new"},
+        }
+
+    def test_dict2_wins_on_scalar_conflict(self):
+        assert main.deep_merge({"k": 1}, {"k": 2}) == {"k": 2}
+
+    def test_lists_are_replaced_not_merged(self):
+        assert main.deep_merge({"k": [1, 2]}, {"k": [3]}) == {"k": [3]}
+
+    def test_dict_replaced_by_scalar_from_dict2(self):
+        assert main.deep_merge({"k": {"x": 1}}, {"k": 5}) == {"k": 5}
+
+    def test_scalar_replaced_by_dict_from_dict2(self):
+        assert main.deep_merge({"k": 5}, {"k": {"x": 1}}) == {"k": {"x": 1}}
+
+    def test_inputs_are_not_mutated(self):
+        dict1 = {"a": {"x": 1}}
+        dict2 = {"a": {"y": 2}}
+        main.deep_merge(dict1, dict2)
+        assert dict1 == {"a": {"x": 1}}
+        assert dict2 == {"a": {"y": 2}}
+
+    def test_result_is_deepcopy_independent_of_inputs(self):
+        dict1 = {"nested": {"x": 1}}
+        dict2 = {"other": 2}
+        result = main.deep_merge(dict1, dict2)
+        result["nested"]["x"] = 999
+        assert dict1["nested"]["x"] == 1
+
+
+class TestGetResourceName:
+    """``get_resource_name`` resolves name -> address -> id -> 'unknown'."""
+
+    def test_prefers_name(self):
+        resource = SimpleNamespace(name="my-name", address="1.2.3.4/32", id=7)
+        assert main.get_resource_name(resource) == "my-name"
+
+    def test_falls_back_to_address(self):
+        resource = SimpleNamespace(address="1.2.3.4/32", id=7)
+        assert main.get_resource_name(resource) == "1.2.3.4/32"
+
+    def test_falls_back_to_id(self):
+        resource = SimpleNamespace(id=7)
+        assert main.get_resource_name(resource) == 7
+
+    def test_falls_back_to_unknown(self):
+        assert main.get_resource_name(SimpleNamespace()) == "unknown"
+
+
+class TestGetDeviceRoleSlug:
+    """``get_device_role_slug`` prefers role.slug, then role.name, lowercased."""
+
+    def test_prefers_slug_lowercased(self, make_device):
+        device = make_device(role_slug="Control")
+        assert main.get_device_role_slug(device) == "control"
+
+    def test_prefers_slug_over_name(self, make_device):
+        device = make_device(role_slug="Leaf", role_name="Some Name")
+        assert main.get_device_role_slug(device) == "leaf"
+
+    def test_falls_back_to_name_lowercased(self, make_device):
+        device = make_device(role_name="Compute")
+        assert main.get_device_role_slug(device) == "compute"
+
+    def test_returns_empty_when_role_is_falsy(self, make_device):
+        device = make_device()  # role defaults to None
+        assert main.get_device_role_slug(device) == ""
+
+    def test_returns_empty_when_role_has_neither_attribute(self):
+        device = SimpleNamespace(role=SimpleNamespace())
+        assert main.get_device_role_slug(device) == ""
+
+
+class TestFindDeviceNamesInStructure:
+    """``find_device_names_in_structure`` collects every string device name."""
+
+    def test_empty_structure_returns_empty(self):
+        assert main.find_device_names_in_structure({}) == []
+
+    def test_flat_structure_without_device_returns_empty(self):
+        assert main.find_device_names_in_structure({"name": "x", "vid": 1}) == []
+
+    def test_collects_top_level_device(self):
+        assert main.find_device_names_in_structure({"device": "node-0"}) == ["node-0"]
+
+    def test_ignores_non_string_device_values(self):
+        assert main.find_device_names_in_structure({"device": 123}) == []
+
+    def test_collects_from_lists_of_dicts(self):
+        data = {"items": [{"device": "a"}, {"device": "b"}]}
+        assert main.find_device_names_in_structure(data) == ["a", "b"]
+
+    def test_collects_from_deep_nesting(self):
+        data = {"a": {"b": {"c": {"device": "deep"}}}}
+        assert main.find_device_names_in_structure(data) == ["deep"]
+
+    def test_collects_multiple_nested_devices(self):
+        data = {
+            "termination_a": {"device": "switch-1"},
+            "termination_b": {"device": "node-0"},
+        }
+        assert main.find_device_names_in_structure(data) == ["switch-1", "node-0"]
+
+
+class TestIsVirtualInterface:
+    """``is_virtual_interface`` is true when type.value/label contains virtual."""
+
+    def test_true_when_value_contains_virtual(self, make_interface):
+        assert main.is_virtual_interface(make_interface(type_value="virtual")) is True
+
+    def test_value_match_is_case_insensitive(self, make_interface):
+        assert main.is_virtual_interface(make_interface(type_value="VIRTUAL")) is True
+
+    def test_true_when_value_contains_virtual_as_substring(self, make_interface):
+        interface = make_interface(type_value="bridge-virtual")
+        assert main.is_virtual_interface(interface) is True
+
+    def test_true_when_label_contains_virtual(self, make_interface):
+        interface = make_interface(type_label="Virtual Interface")
+        assert main.is_virtual_interface(interface) is True
+
+    def test_label_used_when_value_does_not_match(self, make_interface):
+        interface = make_interface(type_value="1000base-t", type_label="Virtual")
+        assert main.is_virtual_interface(interface) is True
+
+    def test_false_when_type_is_falsy(self, make_interface):
+        assert main.is_virtual_interface(make_interface()) is False
+
+    def test_false_when_value_does_not_match(self, make_interface):
+        assert (
+            main.is_virtual_interface(make_interface(type_value="1000base-t")) is False
+        )
+
+    def test_false_when_type_has_neither_attribute(self):
+        interface = SimpleNamespace(type=SimpleNamespace())
+        assert main.is_virtual_interface(interface) is False
+
+
+class TestSplitTasksByType:
+    """``_split_tasks_by_type`` groups tasks by their first dict key."""
+
+    def test_empty_input_returns_empty_dict(self):
+        assert main._split_tasks_by_type([]) == {}
+
+    def test_groups_by_first_key_and_preserves_order(self):
+        tasks = [
+            {"device_interface": {"name": "Ethernet0"}},
+            {"cable": {"type": "cat6a"}},
+            {"device_interface": {"name": "Ethernet1"}},
+        ]
+        result = main._split_tasks_by_type(tasks)
+        assert result == {
+            "device_interface": [
+                {"device_interface": {"name": "Ethernet0"}},
+                {"device_interface": {"name": "Ethernet1"}},
+            ],
+            "cable": [{"cable": {"type": "cat6a"}}],
+        }
+        # Resource types appear in first-seen order; tasks keep their order.
+        assert list(result.keys()) == ["device_interface", "cable"]

--- a/tests/unit/netbox_manager/test_loopback_gate.py
+++ b/tests/unit/netbox_manager/test_loopback_gate.py
@@ -56,8 +56,14 @@ class TestShouldHaveLoopbackInterface:
         assert main.should_have_loopback_interface(device) is True
 
     def test_node_role_does_not_require_hwsku(self, make_device):
-        # "control" is a node role; the empty default custom_fields is fine.
-        device = make_device(role_slug="control")
+        # The node-role path short-circuits before the hwsku check, so a node
+        # role gets Loopback0 even with a SONiC hwsku present -- the opposite
+        # hwsku state from ``test_node_role_always_gets_loopback`` (which has
+        # none). Together the two pin node-role eligibility as hwsku-independent.
+        device = make_device(
+            role_slug="control",
+            custom_fields={"sonic_parameters": {"hwsku": "AS7326"}},
+        )
         assert main.should_have_loopback_interface(device) is True
 
     def test_switch_role_with_hwsku_gets_loopback(self, make_device):

--- a/tests/unit/netbox_manager/test_loopback_gate.py
+++ b/tests/unit/netbox_manager/test_loopback_gate.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the loopback-gate helpers in ``netbox_manager.main`` (issue #247).
+
+Covers group 5 of the Tier 1 scope tracked in #232: whether a device carries a
+``sonic_parameters.hwsku`` custom field, and whether a device should get a
+Loopback0 interface. The loopback decision reads the settings-driven role lists
+from group 1, so a few cases stub ``main.settings`` to exercise overrides.
+"""
+
+from types import SimpleNamespace
+
+from netbox_manager import main
+
+
+class TestHasSonicHwskuParameter:
+    """``has_sonic_hwsku_parameter`` is true only for a dict hwsku value."""
+
+    def test_false_when_custom_fields_attribute_missing(self):
+        assert main.has_sonic_hwsku_parameter(SimpleNamespace()) is False
+
+    def test_false_when_custom_fields_falsy(self, make_device):
+        # make_device defaults custom_fields to an empty (falsy) dict.
+        assert main.has_sonic_hwsku_parameter(make_device()) is False
+
+    def test_false_when_sonic_parameters_absent(self, make_device):
+        device = make_device(custom_fields={"other": 1})
+        assert main.has_sonic_hwsku_parameter(device) is False
+
+    def test_false_when_sonic_parameters_not_a_dict(self, make_device):
+        device = make_device(custom_fields={"sonic_parameters": "not-a-dict"})
+        assert main.has_sonic_hwsku_parameter(device) is False
+
+    def test_false_when_hwsku_missing(self, make_device):
+        device = make_device(custom_fields={"sonic_parameters": {"foo": "bar"}})
+        assert main.has_sonic_hwsku_parameter(device) is False
+
+    def test_false_when_hwsku_empty(self, make_device):
+        device = make_device(custom_fields={"sonic_parameters": {"hwsku": ""}})
+        assert main.has_sonic_hwsku_parameter(device) is False
+
+    def test_true_when_hwsku_present(self, make_device):
+        device = make_device(custom_fields={"sonic_parameters": {"hwsku": "AS7326"}})
+        assert main.has_sonic_hwsku_parameter(device) is True
+
+
+class TestShouldHaveLoopbackInterface:
+    """``should_have_loopback_interface`` gates by role and SONiC hwsku.
+
+    These cases rely on the in-module default role lists, since the conftest
+    settings stub leaves NODE_ROLES / SWITCH_ROLES unset.
+    """
+
+    def test_node_role_always_gets_loopback(self, make_device):
+        device = make_device(role_slug="control")
+        assert main.should_have_loopback_interface(device) is True
+
+    def test_node_role_does_not_require_hwsku(self, make_device):
+        # "control" is a node role; the empty default custom_fields is fine.
+        device = make_device(role_slug="control")
+        assert main.should_have_loopback_interface(device) is True
+
+    def test_switch_role_with_hwsku_gets_loopback(self, make_device):
+        device = make_device(
+            role_slug="leaf",
+            custom_fields={"sonic_parameters": {"hwsku": "AS7326"}},
+        )
+        assert main.should_have_loopback_interface(device) is True
+
+    def test_switch_role_without_hwsku_no_loopback(self, make_device):
+        device = make_device(role_slug="leaf")
+        assert main.should_have_loopback_interface(device) is False
+
+    def test_switch_device_type_with_hwsku_gets_loopback(self, make_device):
+        device = make_device(
+            role_slug="unmapped",
+            device_type_model="Generic Switch",
+            custom_fields={"sonic_parameters": {"hwsku": "AS7326"}},
+        )
+        assert main.should_have_loopback_interface(device) is True
+
+    def test_switch_device_type_without_hwsku_no_loopback(self, make_device):
+        device = make_device(role_slug="unmapped", device_type_model="Generic Switch")
+        assert main.should_have_loopback_interface(device) is False
+
+    def test_non_node_non_switch_no_loopback(self, make_device):
+        device = make_device(role_slug="unmapped", device_type_model="Server")
+        assert main.should_have_loopback_interface(device) is False
+
+    def test_no_role_and_no_device_type_no_loopback(self, make_device):
+        assert main.should_have_loopback_interface(make_device()) is False
+
+    def test_custom_node_role_from_settings(self, make_device, monkeypatch):
+        monkeypatch.setattr(main.settings, "NODE_ROLES", ["myrole"], raising=False)
+        device = make_device(role_slug="myrole")
+        assert main.should_have_loopback_interface(device) is True
+
+    def test_settings_override_replaces_default_node_roles(
+        self, make_device, monkeypatch
+    ):
+        # Overriding NODE_ROLES replaces the defaults, so "control" no longer
+        # counts as a node role and the device gets no loopback.
+        monkeypatch.setattr(main.settings, "NODE_ROLES", ["myrole"], raising=False)
+        device = make_device(role_slug="control")
+        assert main.should_have_loopback_interface(device) is False
+
+    def test_custom_switch_role_from_settings(self, make_device, monkeypatch):
+        monkeypatch.setattr(main.settings, "SWITCH_ROLES", ["myswitch"], raising=False)
+        device = make_device(
+            role_slug="myswitch",
+            custom_fields={"sonic_parameters": {"hwsku": "AS7326"}},
+        )
+        assert main.should_have_loopback_interface(device) is True

--- a/tests/unit/netbox_manager/test_task_filters.py
+++ b/tests/unit/netbox_manager/test_task_filters.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the task-filter helpers in ``netbox_manager.main`` (issue #247).
+
+Covers group 3 of the Tier 1 scope tracked in #232: the helpers that decide
+whether a task is skipped by a ``--limit`` task-type filter or a device filter,
+and the helper that extracts device names from a task. All operate on plain
+dicts/lists, so they need no mocks.
+"""
+
+from netbox_manager import main
+
+
+class TestShouldSkipTaskByFilter:
+    """``should_skip_task_by_filter`` compares key and filter after `-`/`_`."""
+
+    def test_exact_match_does_not_skip(self):
+        assert main.should_skip_task_by_filter("device", "device") is False
+
+    def test_dash_key_matches_underscore_filter(self):
+        assert (
+            main.should_skip_task_by_filter("device-interface", "device_interface")
+            is False
+        )
+
+    def test_underscore_key_matches_dash_filter(self):
+        assert (
+            main.should_skip_task_by_filter("device_interface", "device-interface")
+            is False
+        )
+
+    def test_mismatch_skips(self):
+        assert main.should_skip_task_by_filter("cable", "device") is True
+
+    def test_mismatch_skips_even_after_normalisation(self):
+        assert main.should_skip_task_by_filter("device-interface", "cable") is True
+
+
+class TestExtractDeviceNamesFromTask:
+    """``extract_device_names_from_task`` gathers direct and nested names."""
+
+    def test_direct_device_field(self):
+        value = {"device": "node-0"}
+        # Collected once directly and once by the nested search: no dedup.
+        assert main.extract_device_names_from_task("device_interface", value) == [
+            "node-0",
+            "node-0",
+        ]
+
+    def test_device_creation_task_uses_name(self):
+        value = {"name": "testbed-node-0", "site": "Discworld"}
+        assert main.extract_device_names_from_task("device", value) == [
+            "testbed-node-0"
+        ]
+
+    def test_device_creation_task_without_name_yields_nothing(self):
+        assert (
+            main.extract_device_names_from_task("device", {"site": "Discworld"}) == []
+        )
+
+    def test_nested_names_only(self):
+        value = {
+            "termination_a": {"device": "switch-1"},
+            "termination_b": {"device": "node-0"},
+        }
+        assert main.extract_device_names_from_task("cable", value) == [
+            "switch-1",
+            "node-0",
+        ]
+
+    def test_combines_direct_and_nested_without_dedup(self):
+        value = {"device": "node-0", "extra": {"device": "node-9"}}
+        assert main.extract_device_names_from_task("device_interface", value) == [
+            "node-0",  # direct device field
+            "node-0",  # same value re-collected by the nested search
+            "node-9",  # nested device
+        ]
+
+
+class TestShouldSkipTaskByDeviceFilter:
+    """``should_skip_task_by_device_filter`` skips on empty/no-match."""
+
+    def test_empty_device_names_skips(self):
+        assert main.should_skip_task_by_device_filter([], ["node"]) is True
+
+    def test_substring_match_does_not_skip(self):
+        assert (
+            main.should_skip_task_by_device_filter(["testbed-node-0"], ["node"])
+            is False
+        )
+
+    def test_no_match_skips(self):
+        assert main.should_skip_task_by_device_filter(["node-0"], ["switch"]) is True
+
+    def test_any_matching_filter_does_not_skip(self):
+        assert (
+            main.should_skip_task_by_device_filter(["node-0"], ["switch", "node"])
+            is False
+        )
+
+    def test_any_matching_device_name_does_not_skip(self):
+        assert (
+            main.should_skip_task_by_device_filter(["switch-1", "node-0"], ["node"])
+            is False
+        )


### PR DESCRIPTION
## Summary

Closes #247 — Tier 1 of the #232 unit-test rollout: unit tests for the
pure-logic helpers in `netbox_manager/main.py`. These functions are
deterministic transformations of plain Python data or tiny attribute-bag
objects, so the tests need no live NetBox, `ansible_runner`, filesystem, or
full `pynetbox` mocks — at most a `types.SimpleNamespace`.

Builds on the #233/#234 foundation (pytest harness, `tests/` tree,
`test-requirements.txt`, shared `conftest.py`, Zuul `netbox-manager-unit-tests`
job).

## Change set (commit order)

1. **Add shared device/interface factories to test conftest** — `make_device`
   and `make_interface` fixtures producing `SimpleNamespace` attribute bags,
   documented for reuse by later tiers.
2. **settings/role and generic helpers** (`test_helpers.py`, groups 1+2) —
   `get_node_roles`, `get_switch_roles`, `deep_merge`, `get_leading_number`,
   `get_resource_name`, `get_device_role_slug`,
   `find_device_names_in_structure`, `is_virtual_interface`,
   `_split_tasks_by_type`.
3. **task-filter helpers** (`test_task_filters.py`, group 3) —
   `should_skip_task_by_filter`, `extract_device_names_from_task`,
   `should_skip_task_by_device_filter`.
4. **autoconf helpers** (`test_autoconf_helpers.py`, group 4) —
   `get_autoconf_prefix`, `_extract_device_names_from_autoconf_task`,
   `_filter_tasks_by_device`, `_filter_tasks_by_type_by_device`,
   `_filter_portchannel_tasks_by_device`.
5. **loopback-gate helpers** (`test_loopback_gate.py`, group 5) —
   `has_sonic_hwsku_parameter`, `should_have_loopback_interface` (including
   settings-driven role-list overrides).

92 new tests; `pytest tests/unit` now reports 117 passed.

## Local verification

- `pytest tests/unit` — 117 passed
- `flake8 tests/ netbox_manager/` — clean
- `black --check tests/ netbox_manager/` — clean
- `mypy netbox_manager/` — unchanged from baseline (pre-existing
  `import-untyped` notes for untyped third-party libraries; the new test files
  add no errors of their own)
- `yamllint` — unchanged (no YAML touched)

## Notes for reviewers

- The settings-stub cases use
  `monkeypatch.setattr(main.settings, "NODE_ROLES", ..., raising=False)`: the
  keys are not real attributes on the Dynaconf object, so `raising=False` is
  required, and monkeypatch's teardown restores the absent → default-fallback
  state.
- The `make_device` / `make_interface` factories are deliberately minimal —
  they expose only the attributes these helpers read. Later #232 tiers should
  extend them in place rather than re-deriving device/interface shapes.

Part of #232.