### PR TITLE
Unit tests: Tier 2 — task / playbook builders in main.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,14 @@ from types import SimpleNamespace
 import pytest
 
 # Set dynaconf env vars before any test imports `netbox_manager.main`, since
-# `Dynaconf(...)` and the validator registration run at import time. Defaults
-# are used so tests do not depend on a real `settings.toml` being present.
-os.environ.setdefault("NETBOX_MANAGER_URL", "http://localhost:8000")
-os.environ.setdefault("NETBOX_MANAGER_TOKEN", "test-token")
-os.environ.setdefault("NETBOX_MANAGER_IGNORE_SSL_ERRORS", "false")
+# `Dynaconf(...)` and the validator registration run at import time. Force-set
+# (not `setdefault`) so an exported `NETBOX_MANAGER_URL`/`TOKEN`/
+# `IGNORE_SSL_ERRORS` from a real deployment cannot leak into tests that
+# assert these baseline values, and tests do not depend on a real
+# `settings.toml` being present.
+os.environ["NETBOX_MANAGER_URL"] = "http://localhost:8000"
+os.environ["NETBOX_MANAGER_TOKEN"] = "test-token"
+os.environ["NETBOX_MANAGER_IGNORE_SSL_ERRORS"] = "false"
 
 # Keep the role helpers hermetic. A real deployment env may export
 # `NETBOX_MANAGER_NODE_ROLES` / `..._SWITCH_ROLES`, which dynaconf would load as

--- a/tests/unit/netbox_manager/test_playbook_rendering.py
+++ b/tests/unit/netbox_manager/test_playbook_rendering.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for playbook rendering in ``netbox_manager.main`` (issue #249).
+
+Covers groups 3 and 4 of the Tier 2 scope tracked in #232:
+``create_ansible_playbook`` (which renders ``playbook_template`` into a single
+play) and ``ProperIndentDumper`` (the YAML dumper that indents nested sequences
+under their key). Both are deterministic transformations of plain Python data;
+the round-trip assertions parse the rendered/dumped strings back with
+``yaml.safe_load`` -- no filesystem is involved.
+"""
+
+import yaml
+
+from netbox_manager import main
+
+
+class TestCreateAnsiblePlaybook:
+    """``create_ansible_playbook`` renders one play from vars and tasks."""
+
+    def test_single_play_with_basename_and_connection_settings(self):
+        result = main.create_ansible_playbook(
+            "/some/dir/300-devices.yml", {"site": "Disc"}, []
+        )
+        plays = yaml.safe_load(result)
+        assert isinstance(plays, list)
+        assert len(plays) == 1
+        play = plays[0]
+        # The play name carries only the basename, not the directory part.
+        assert "300-devices.yml" in play["name"]
+        assert "/some/dir" not in play["name"]
+        assert play["connection"] == "local"
+        assert play["hosts"] == "localhost"
+        assert play["gather_facts"] is False
+
+    def test_vars_and_tasks_round_trip(self):
+        template_vars = {"site": "Disc", "nested": {"a": 1, "b": [2, 3]}}
+        # Build a real task via the Tier-2 builder, from a fresh dict (it mutates
+        # its input). This exercises a nested module envelope through indent(4).
+        template_tasks = [main.create_netbox_task("vlan", {"name": "OOB", "vid": 100})]
+
+        result = main.create_ansible_playbook("x.yml", template_vars, template_tasks)
+        play = yaml.safe_load(result)[0]
+
+        # indent(4) must not corrupt the nested structures on the way through.
+        assert play["vars"] == template_vars
+        assert play["tasks"] == template_tasks
+
+    def test_empty_vars_renders_parseable_yaml(self):
+        template_tasks = [main.create_netbox_task("vlan", {"name": "OOB"})]
+        play = yaml.safe_load(
+            main.create_ansible_playbook("x.yml", {}, template_tasks)
+        )[0]
+        assert play["vars"] == {}
+        assert play["tasks"] == template_tasks
+
+    def test_empty_tasks_renders_parseable_yaml(self):
+        play = yaml.safe_load(
+            main.create_ansible_playbook("x.yml", {"site": "Disc"}, [])
+        )[0]
+        assert play["tasks"] == []
+        assert play["vars"] == {"site": "Disc"}
+
+    def test_empty_vars_and_tasks_render_parseable_yaml(self):
+        play = yaml.safe_load(main.create_ansible_playbook("x.yml", {}, []))[0]
+        assert play["vars"] == {}
+        assert play["tasks"] == []
+
+
+class TestProperIndentDumper:
+    """``ProperIndentDumper`` indents nested sequences under their parent key."""
+
+    def test_nested_sequence_is_indented(self):
+        data = {"name": "x", "tags": ["a", "b"]}
+
+        dumped = yaml.dump(
+            data, Dumper=main.ProperIndentDumper, default_flow_style=False
+        )
+        # The sequence is indented under `tags:` rather than aligned with it.
+        assert "  - a" in dumped
+
+        # Contrast: the stock dumper produces indentless sequences for the same
+        # input, so the bullet sits at the parent key's column.
+        default_dumped = yaml.dump(data, default_flow_style=False)
+        assert "\n- a" in default_dumped
+
+    def test_round_trip_with_autoconf_dump_signature(self):
+        # Nested task shapes `_write_autoconf_files` emits: a device_interface
+        # task with a nested `data` dict carrying `tagged_vlans`/`tags` lists,
+        # and a cable task with nested termination dicts.
+        data = [
+            {
+                "name": "Manage NetBox resource Ethernet1 of type device_interface",
+                "netbox.netbox.netbox_device_interface": {
+                    "data": {
+                        "device": "switch-0",
+                        "name": "Ethernet1",
+                        "mode": "tagged",
+                        "tagged_vlans": [
+                            {"name": "Management"},
+                            {"name": "External"},
+                        ],
+                        "tags": ["managed-by-osism"],
+                    },
+                    "state": "present",
+                },
+            },
+            {
+                "name": "Manage NetBox resource of type cable",
+                "netbox.netbox.netbox_cable": {
+                    "data": {
+                        "type": "cat6a",
+                        "termination_a": {"device": "switch-0", "name": "Ethernet1"},
+                        "termination_b": {"device": "node-0", "name": "Ethernet0"},
+                    },
+                    "state": "present",
+                },
+            },
+        ]
+
+        dumped = yaml.dump(
+            data,
+            Dumper=main.ProperIndentDumper,
+            default_flow_style=False,
+            sort_keys=False,
+            explicit_start=True,
+        )
+        assert yaml.safe_load(dumped) == data

--- a/tests/unit/netbox_manager/test_task_builders.py
+++ b/tests/unit/netbox_manager/test_task_builders.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the task builders in ``netbox_manager.main`` (issue #249).
+
+Covers groups 1 and 2 of the Tier 2 scope tracked in #232: the settings-aware
+builders that turn a YAML resource value into an Ansible task dict --
+``create_netbox_task`` (the ``netbox.netbox.netbox_*`` module envelope) and
+``create_uri_task`` (the ``ansible.builtin.uri`` direct API call). Both read
+``settings.URL`` / ``settings.TOKEN`` / ``settings.IGNORE_SSL_ERRORS`` at call
+time; the baseline comes from the conftest dynaconf env stub and branch-specific
+values are injected with ``monkeypatch.setattr(main.settings, ..., raising=False)``
+(``raising=False`` because dynaconf resolves keys through ``__getattr__``).
+
+These builders mutate their ``value`` argument (``pop("state")`` and, for
+``device_interface``, ``pop("update_vc_child")``), so every test passes a fresh
+dict literal.
+"""
+
+from netbox_manager import main
+
+
+class TestCreateNetboxTask:
+    """``create_netbox_task`` wraps a value in the netbox module envelope."""
+
+    def test_default_state_is_present(self):
+        task = main.create_netbox_task("vlan", {"name": "OOB"})
+        assert task["netbox.netbox.netbox_vlan"]["state"] == "present"
+
+    def test_explicit_state_popped_and_removed_from_data(self):
+        value = {"name": "OOB", "state": "absent"}
+        task = main.create_netbox_task("vlan", value)
+        module = task["netbox.netbox.netbox_vlan"]
+        assert module["state"] == "absent"
+        # The state is moved into the envelope, not left inside data...
+        assert "state" not in module["data"]
+        # ...and the caller's dict is mutated in place (pin this behaviour).
+        assert "state" not in value
+
+    def test_module_envelope_fields(self):
+        value = {"name": "OOB", "vid": 100}
+        task = main.create_netbox_task("vlan", value)
+        # Only the task name and the single module key are present.
+        assert set(task) == {"name", "netbox.netbox.netbox_vlan"}
+        module = task["netbox.netbox.netbox_vlan"]
+        assert module["data"] == {"name": "OOB", "vid": 100}
+        assert module["state"] == "present"
+        assert module["netbox_token"] == "test-token"
+        assert module["netbox_url"] == "http://localhost:8000"
+        assert module["validate_certs"] is True
+
+    def test_validate_certs_true_when_ssl_errors_not_ignored(self):
+        # Baseline conftest stub: IGNORE_SSL_ERRORS is false.
+        task = main.create_netbox_task("vlan", {"name": "OOB"})
+        assert task["netbox.netbox.netbox_vlan"]["validate_certs"] is True
+
+    def test_validate_certs_false_when_ssl_errors_ignored(self, monkeypatch):
+        monkeypatch.setattr(main.settings, "IGNORE_SSL_ERRORS", True, raising=False)
+        task = main.create_netbox_task("vlan", {"name": "OOB"})
+        assert task["netbox.netbox.netbox_vlan"]["validate_certs"] is False
+
+    def test_envelope_reads_settings_at_call_time(self, monkeypatch):
+        monkeypatch.setattr(
+            main.settings, "URL", "https://netbox.example.org", raising=False
+        )
+        monkeypatch.setattr(main.settings, "TOKEN", "other-token", raising=False)
+        task = main.create_netbox_task("vlan", {"name": "OOB"})
+        module = task["netbox.netbox.netbox_vlan"]
+        assert module["netbox_url"] == "https://netbox.example.org"
+        assert module["netbox_token"] == "other-token"
+
+    def test_token_is_stringified(self, monkeypatch):
+        # A numeric token from settings is coerced to str(settings.TOKEN).
+        monkeypatch.setattr(main.settings, "TOKEN", 12345, raising=False)
+        task = main.create_netbox_task("vlan", {"name": "OOB"})
+        assert task["netbox.netbox.netbox_vlan"]["netbox_token"] == "12345"
+
+    def test_task_name_format(self):
+        task = main.create_netbox_task("vlan", {"name": "OOB"})
+        assert task["name"] == "Manage NetBox resource OOB of type vlan"
+
+    def test_task_name_collapses_double_space_when_no_name(self):
+        # No `name` key -> the empty interpolation leaves a double space that
+        # `.replace("  ", " ")` collapses to a single space.
+        task = main.create_netbox_task("vlan", {"vid": 100})
+        assert task["name"] == "Manage NetBox resource of type vlan"
+
+    def test_update_vc_child_beside_data_for_device_interface(self):
+        value = {"device": "node-0", "name": "Eth0", "update_vc_child": True}
+        task = main.create_netbox_task("device_interface", value)
+        module = task["netbox.netbox.netbox_device_interface"]
+        # Lifted out of data and placed beside it at the module level.
+        assert module["update_vc_child"] is True
+        assert "update_vc_child" not in module["data"]
+
+    def test_update_vc_child_stays_in_data_for_other_keys(self):
+        value = {"name": "node-0", "update_vc_child": True}
+        task = main.create_netbox_task("device", value)
+        module = task["netbox.netbox.netbox_device"]
+        # For any non-device_interface key it is left untouched inside data.
+        assert module["data"]["update_vc_child"] is True
+        assert "update_vc_child" not in module
+
+    def test_register_added_only_when_truthy(self):
+        with_register = main.create_netbox_task(
+            "vlan", {"name": "OOB"}, register_var="result"
+        )
+        assert with_register["register"] == "result"
+
+        no_register = main.create_netbox_task("vlan", {"name": "OOB"})
+        assert "register" not in no_register
+
+        empty_register = main.create_netbox_task(
+            "vlan", {"name": "OOB"}, register_var=""
+        )
+        assert "register" not in empty_register
+
+    def test_ignore_errors_added_only_when_true(self):
+        with_ignore = main.create_netbox_task(
+            "vlan", {"name": "OOB"}, ignore_errors=True
+        )
+        assert with_ignore["ignore_errors"] is True
+
+        no_ignore = main.create_netbox_task("vlan", {"name": "OOB"})
+        assert "ignore_errors" not in no_ignore
+
+
+class TestCreateUriTask:
+    """``create_uri_task`` builds an ``ansible.builtin.uri`` API-call task."""
+
+    def test_strips_api_prefix_with_leading_slash(self):
+        task = main.create_uri_task({"path": "/api/dcim/devices/"})
+        uri = task["ansible.builtin.uri"]
+        assert uri["url"] == "http://localhost:8000/api/dcim/devices/"
+        # The normalized path (prefix stripped) is what the name reports.
+        assert task["name"] == "NetBox API call: GET dcim/devices/"
+
+    def test_strips_api_prefix_without_leading_slash(self):
+        task = main.create_uri_task({"path": "api/dcim/"})
+        assert task["ansible.builtin.uri"]["url"] == "http://localhost:8000/api/dcim/"
+
+    def test_strips_remaining_leading_slashes(self):
+        task = main.create_uri_task({"path": "/dcim/devices"})
+        assert (
+            task["ansible.builtin.uri"]["url"]
+            == "http://localhost:8000/api/dcim/devices"
+        )
+
+    def test_trailing_slash_url_does_not_produce_double_slash(self, monkeypatch):
+        monkeypatch.setattr(
+            main.settings, "URL", "http://localhost:8000/", raising=False
+        )
+        task = main.create_uri_task({"path": "dcim"})
+        assert task["ansible.builtin.uri"]["url"] == "http://localhost:8000/api/dcim"
+
+    def test_empty_path_yields_api_root(self):
+        task = main.create_uri_task({})
+        assert task["ansible.builtin.uri"]["url"] == "http://localhost:8000/api/"
+
+    def test_method_defaults_to_get(self):
+        task = main.create_uri_task({"path": "dcim/devices"})
+        assert task["ansible.builtin.uri"]["method"] == "GET"
+        # Empty path is not in play here, but the name still leads with GET.
+        assert task["name"].startswith("NetBox API call: GET")
+
+    def test_explicit_method_passed_through(self):
+        task = main.create_uri_task({"path": "dcim/devices/1/", "method": "PATCH"})
+        assert task["ansible.builtin.uri"]["method"] == "PATCH"
+        assert "PATCH" in task["name"]
+
+    def test_headers(self):
+        headers = main.create_uri_task({"path": "dcim"})["ansible.builtin.uri"][
+            "headers"
+        ]
+        assert headers["Authorization"] == "Token test-token"
+        assert headers["Accept"] == "application/json"
+        assert headers["Content-Type"] == "application/json"
+
+    def test_validate_certs_true_when_ssl_errors_not_ignored(self):
+        task = main.create_uri_task({"path": "dcim"})
+        assert task["ansible.builtin.uri"]["validate_certs"] is True
+
+    def test_validate_certs_false_when_ssl_errors_ignored(self, monkeypatch):
+        monkeypatch.setattr(main.settings, "IGNORE_SSL_ERRORS", True, raising=False)
+        task = main.create_uri_task({"path": "dcim"})
+        assert task["ansible.builtin.uri"]["validate_certs"] is False
+
+    def test_empty_body_removes_body_and_body_format(self):
+        # Missing body -> both keys are deleted (GET branch).
+        uri = main.create_uri_task({"path": "dcim"})["ansible.builtin.uri"]
+        assert "body" not in uri
+        assert "body_format" not in uri
+
+    def test_explicitly_empty_body_removes_body_and_body_format(self):
+        uri = main.create_uri_task({"path": "dcim", "body": {}})["ansible.builtin.uri"]
+        assert "body" not in uri
+        assert "body_format" not in uri
+
+    def test_nonempty_body_kept_with_json_format(self):
+        uri = main.create_uri_task(
+            {"path": "dcim", "method": "POST", "body": {"name": "node-0"}}
+        )["ansible.builtin.uri"]
+        assert uri["body"] == {"name": "node-0"}
+        assert uri["body_format"] == "json"
+
+    def test_status_code_is_fixed(self):
+        uri = main.create_uri_task({"path": "dcim"})["ansible.builtin.uri"]
+        assert uri["status_code"] == [200, 201, 204]
+
+    def test_register_added_only_when_truthy(self):
+        with_register = main.create_uri_task({"path": "dcim"}, register_var="result")
+        assert with_register["register"] == "result"
+
+        no_register = main.create_uri_task({"path": "dcim"})
+        assert "register" not in no_register
+
+        empty_register = main.create_uri_task({"path": "dcim"}, register_var="")
+        assert "register" not in empty_register
+
+    def test_ignore_errors_added_only_when_true(self):
+        with_ignore = main.create_uri_task({"path": "dcim"}, ignore_errors=True)
+        assert with_ignore["ignore_errors"] is True
+
+        no_ignore = main.create_uri_task({"path": "dcim"})
+        assert "ignore_errors" not in no_ignore


### PR DESCRIPTION
## Summary

Tier 2 of the #232 unit-test rollout: lock down the four **settings-aware
task / playbook builders** in `netbox_manager/main.py` that turn YAML
resource definitions into Ansible task dicts and rendered playbook strings.
The tests are pure data-in/data-out — no live NetBox, no `ansible_runner`,
no filesystem, no `pynetbox` mocks. They use the existing conftest dynaconf
env stub for the baseline and per-test `monkeypatch.setattr(main.settings,
..., raising=False)` for the two branch-specific settings (trailing-slash
`URL`, `IGNORE_SSL_ERRORS=True`).

Test-only change: **no production code is touched**, no new package, and no
new `conftest.py` fixtures.

Closes #249

## Change set (in commit order)

1. **Add unit tests for NetBox and URI task builders**
   — `tests/unit/netbox_manager/test_task_builders.py` (groups 1 & 2)
   - `TestCreateNetboxTask` — `state` default + caller-dict mutation, the
     `netbox.netbox.netbox_<key>` module envelope, `validate_certs` in both
     polarities, settings read at call time, token stringification, the
     task-name double-space collapse, `update_vc_child` placement for
     `device_interface` vs. other keys, conditional `register` /
     `ignore_errors`.
   - `TestCreateUriTask` — `/api/` & `api/` prefix stripping, remaining
     leading-slash removal, the trailing-slash URL guard, empty-path root,
     method default/passthrough, JSON headers, `validate_certs` polarities,
     empty vs. non-empty body handling, the fixed `status_code`, conditional
     `register` / `ignore_errors`.

2. **Add unit tests for playbook rendering and YAML dumper**
   — `tests/unit/netbox_manager/test_playbook_rendering.py` (groups 3 & 4)
   - `TestCreateAnsiblePlaybook` — single-play envelope with `basename` and
     `connection: local` / `hosts: localhost` / `gather_facts: false`, a
     vars/tasks round-trip through `yaml.safe_load` (verifying the Jinja
     `indent(4)` filter does not corrupt nesting), and the empty-vars /
     empty-tasks / both-empty edge shapes.
   - `TestProperIndentDumper` — nested sequences indented under their key
     (asserted on the dumped string, contrasted with the indentless stock
     dumper) and a round-trip with the exact `_write_autoconf_files` dump
     signature (`Dumper=ProperIndentDumper, default_flow_style=False,
     sort_keys=False, explicit_start=True`).

Every builder that mutates its `value` argument (`create_netbox_task` pops
`state` / `update_vc_child`; the round-trip test reuses `create_netbox_task`)
is fed a fresh dict literal per call.

## Acceptance Criteria coverage

All four function groups (1–4) and their listed branches are covered. The
two settings-branch criteria (trailing-slash URL, `IGNORE_SSL_ERRORS=True`)
use `monkeypatch.setattr(main.settings, ..., raising=False)` as required.

## Definition of Done notes

- `pytest tests/unit` is green locally (152 passed, +36 new).
- `flake8` and `black --check` are green for the new files.
- The DoD item *"document new shared fixtures"* is satisfied vacuously: this
  tier needs **no** new `conftest.py` fixtures — the existing env stub plus
  per-test `monkeypatch` overrides suffice — so there is nothing new to
  document for later tiers.

## Local verification

| Command | Result |
| --- | --- |
| `.venv/bin/python -m pytest tests/unit` | 152 passed |
| `.venv/bin/python -m flake8 <new files>` | clean |
| `.venv/bin/python -m black --check <new files>` | clean |
| `.venv/bin/python -m mypy netbox_manager/` | unchanged (7 pre-existing `import-untyped` errors from missing local stubs; resolved in CI) |
| `yamllint` | unaffected — this change adds no YAML files |

## Out of scope (per the issue)

`handle_file` orchestration, the file-writing part of `_write_autoconf_files`
(`tmp_path`), and anything requiring a `pynetbox.api` client,
`ansible_runner.run`, real filesystem I/O, or `git.Repo` — all later tiers.

---

_Drafted by [planwerk-review](https://github.com/planwerk/planwerk-review) with Claude:claude-opus-4-8_
