### PR TITLE
Unit tests: Tier 4 — handle_file orchestration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 from types import SimpleNamespace
 
 import pytest
+from loguru import logger
 
 # Set dynaconf env vars before any test imports `netbox_manager.main`, since
 # `Dynaconf(...)` and the validator registration run at import time. Force-set
@@ -25,9 +26,11 @@ os.environ["NETBOX_MANAGER_IGNORE_SSL_ERRORS"] = "false"
 os.environ.pop("NETBOX_MANAGER_NODE_ROLES", None)
 os.environ.pop("NETBOX_MANAGER_SWITCH_ROLES", None)
 
-# Heavier per-module fixtures -- full `pynetbox.api` clients, mocked
-# `ansible_runner.run`, `git.Repo`, `subprocess` -- belong to the later #232
-# tiers. Tier 1 (#247) only needs the lightweight attribute-bag factories below.
+# Cross-tier fixtures. The lightweight attribute-bag factories `make_device` /
+# `make_interface` (Tier 1, #247) come first; the heavier `mock_ansible_runner`
+# recorder and the loguru->`caplog` bridge (Tier 4, #252) follow at the end of
+# the file. The remaining heavy seams -- full `pynetbox.api` clients, `git.Repo`,
+# `subprocess` -- belong to the later #232 tiers.
 
 
 @pytest.fixture
@@ -109,3 +112,66 @@ def make_interface():
         return SimpleNamespace(type=interface_type)
 
     return _make_interface
+
+
+@pytest.fixture
+def caplog(caplog):
+    """Bridge loguru log output into pytest's ``caplog`` capture.
+
+    ``netbox_manager.main`` logs via loguru, whose messages pytest's stock
+    ``caplog`` fixture does not see (loguru does not propagate through the
+    standard ``logging`` root). This override -- the recipe from the loguru
+    documentation -- registers ``caplog.handler`` as a loguru sink for the
+    duration of the test, so ``caplog.text`` / ``caplog.records`` capture loguru
+    messages as usual, and removes the sink again on teardown.
+
+    Shared with the later #232 tiers (#256, #258, #259) that assert on the
+    warn / error / info log branches; reuse it rather than re-deriving the
+    bridge per test module.
+    """
+    handler_id = logger.add(
+        caplog.handler,
+        format="{message}",
+        level=0,
+        filter=lambda record: record["level"].no >= caplog.handler.level,
+        enqueue=False,
+    )
+    yield caplog
+    logger.remove(handler_id)
+
+
+@pytest.fixture
+def mock_ansible_runner(monkeypatch):
+    """Replace ``main.ansible_runner`` with a call-recording fake.
+
+    ``handle_file`` invokes ``ansible_runner.run(...)`` to execute a rendered
+    playbook. This fixture swaps the module reference on ``netbox_manager.main``
+    for a recorder that never runs Ansible, so tests can assert both *whether*
+    ``run`` was reached and *with which kwargs*.
+
+    The returned object exposes:
+        calls: list of the keyword-argument dicts passed to each ``run`` call
+            (stays empty when ``run`` is never reached -- dry-run, show-playbooks,
+            no-tasks-after-filter, or an early error return).
+        status: the ``result.status`` string ``run`` reports back; set it to
+            ``"failed"`` before calling ``handle_file`` to drive the fail-fast
+            failure gate.
+
+    ``main`` is imported inside the fixture body to preserve the
+    env-vars-before-import discipline established at the top of this module.
+    Shared with the later #232 tiers (#258) that mock playbook execution.
+    """
+    from netbox_manager import main
+
+    class _RecordingAnsibleRunner:
+        def __init__(self):
+            self.calls = []
+            self.status = "successful"
+
+        def run(self, **kwargs):
+            self.calls.append(kwargs)
+            return SimpleNamespace(status=self.status)
+
+    fake = _RecordingAnsibleRunner()
+    monkeypatch.setattr(main, "ansible_runner", fake)
+    return fake

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 from types import SimpleNamespace
 
 import pytest
+import yaml
 from loguru import logger
 
 # Set dynaconf env vars before any test imports `netbox_manager.main`, since
@@ -137,7 +138,13 @@ def caplog(caplog):
         enqueue=False,
     )
     yield caplog
-    logger.remove(handler_id)
+    try:
+        logger.remove(handler_id)
+    except ValueError:
+        # init_logger()'s bare logger.remove() drops *all* sinks, including
+        # this one -- tests that reach it (the #256/#258/#259 main-path tiers)
+        # would otherwise fail here in teardown.
+        pass
 
 
 @pytest.fixture
@@ -153,6 +160,11 @@ def mock_ansible_runner(monkeypatch):
         calls: list of the keyword-argument dicts passed to each ``run`` call
             (stays empty when ``run`` is never reached -- dry-run, show-playbooks,
             no-tasks-after-filter, or an early error return).
+        playbooks: list (parallel to ``calls``) of the parsed content of each
+            ``playbook`` file, snapshotted at call time. Assert on this rather
+            than reading ``calls[n]["playbook"]`` back from disk afterwards --
+            the temp playbook currently survives ``handle_file`` only due to a
+            leak (no ``dir=`` on the ``NamedTemporaryFile``) that #267 fixes.
         status: the ``result.status`` string ``run`` reports back; set it to
             ``"failed"`` before calling ``handle_file`` to drive the fail-fast
             failure gate.
@@ -166,10 +178,17 @@ def mock_ansible_runner(monkeypatch):
     class _RecordingAnsibleRunner:
         def __init__(self):
             self.calls = []
+            self.playbooks = []
             self.status = "successful"
 
         def run(self, **kwargs):
             self.calls.append(kwargs)
+            playbook = kwargs.get("playbook")
+            if playbook is not None and os.path.isfile(playbook):
+                with open(playbook) as fp:
+                    self.playbooks.append(yaml.safe_load(fp))
+            else:
+                self.playbooks.append(None)
             return SimpleNamespace(status=self.status)
 
     fake = _RecordingAnsibleRunner()

--- a/tests/unit/netbox_manager/test_handle_file.py
+++ b/tests/unit/netbox_manager/test_handle_file.py
@@ -1,0 +1,404 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``handle_file`` orchestration (issue #252, Tier 4 of #232).
+
+``handle_file`` (``netbox_manager.main``) is the glue that loads a YAML resource
+file, validates its structure, dispatches each task to the right builder,
+applies the task / device filters, renders a playbook and -- unless dry-run or
+show-playbooks -- invokes ``ansible_runner.run``. These tests exercise the
+branch logic *inside* ``handle_file``: they drive the **real** Tier 2 builders
+(``create_netbox_task`` / ``create_uri_task`` / ``create_ansible_playbook``,
+tested in #249) and the **real** ``load_global_vars`` (Tier 3), and mock only
+``ansible_runner`` (via the shared ``mock_ansible_runner`` fixture) plus the
+filesystem (via ``tmp_path``). The builders read ``settings.URL`` /
+``settings.TOKEN`` / ``settings.IGNORE_SSL_ERRORS``; the baseline comes from the
+conftest dynaconf env stub (#233).
+
+Log assertions use the shared loguru->``caplog`` bridge from ``conftest.py``.
+Where a PyYAML error message is asserted, only stable substrings are pinned --
+the exact ``problem`` / ``context`` wording varies across PyYAML versions.
+"""
+
+import logging
+
+import pytest
+import typer
+import yaml
+
+from netbox_manager import main
+
+
+@pytest.fixture(autouse=True)
+def _no_global_vars(monkeypatch):
+    """Keep ``load_global_vars`` hermetic across every test in this module.
+
+    A developer environment exporting ``NETBOX_MANAGER_VARS`` would make the
+    real ``load_global_vars`` read files from disk; forcing ``settings.VARS`` to
+    ``None`` makes it return ``{}`` (the real function still runs), so the
+    rendered ``vars`` block reflects only what each test's ``vars`` tasks merge.
+    """
+    monkeypatch.setattr(main.settings, "VARS", None, raising=False)
+
+
+def write_resource_file(tmp_path, text, name="300-test.yml"):
+    """Write ``text`` to a resource file under ``tmp_path`` and return its path."""
+    path = tmp_path / name
+    path.write_text(text)
+    return str(path)
+
+
+def render_playbook(tmp_path, capsys, text, name="300-test.yml", **kwargs):
+    """Render ``text`` through ``handle_file`` in show-playbooks mode.
+
+    Writes ``text`` to a resource file, calls ``handle_file`` with
+    ``show_playbooks=True`` (which prints the rendered playbook to stdout and
+    returns before touching ``ansible_runner``), parses the captured stdout back
+    with ``yaml.safe_load`` (the leading ``# Playbook for ...`` line is a YAML
+    comment) and returns the single play dict.
+    """
+    file = write_resource_file(tmp_path, text, name=name)
+    main.handle_file(file, dryrun=False, show_playbooks=True, **kwargs)
+    out = capsys.readouterr().out
+    assert out.startswith(f"# Playbook for {file}")
+    plays = yaml.safe_load(out)
+    assert isinstance(plays, list) and len(plays) == 1
+    return plays[0]
+
+
+class TestHandleFileLoadErrors:
+    """Group 1 -- file load / IO error branches."""
+
+    def test_missing_file_logs_and_returns(self, tmp_path, caplog, mock_ansible_runner):
+        missing = str(tmp_path / "no-such-file.yml")
+        result = main.handle_file(missing, dryrun=False, fail_fast=False)
+        assert result is None
+        assert "File not found" in caplog.text
+        assert mock_ansible_runner.calls == []
+
+    def test_missing_file_fail_fast_exits(self, tmp_path):
+        missing = str(tmp_path / "no-such-file.yml")
+        with pytest.raises(typer.Exit) as exc_info:
+            main.handle_file(missing, dryrun=False, fail_fast=True)
+        assert exc_info.value.exit_code == 1
+
+    def test_malformed_yaml_logs_position_and_returns(
+        self, tmp_path, caplog, mock_ansible_runner
+    ):
+        # An unterminated flow sequence raises a MarkedYAMLError carrying a
+        # problem_mark, so the message is enriched with line/column.
+        file = write_resource_file(tmp_path, "foo: [1, 2")
+        result = main.handle_file(file, dryrun=False, fail_fast=False)
+        assert result is None
+        assert "Invalid YAML syntax in file" in caplog.text
+        assert "at line" in caplog.text
+        assert "column" in caplog.text
+        assert mock_ansible_runner.calls == []
+
+    def test_malformed_yaml_fail_fast_exits(self, tmp_path):
+        file = write_resource_file(tmp_path, "foo: [1, 2")
+        with pytest.raises(typer.Exit) as exc_info:
+            main.handle_file(file, dryrun=False, fail_fast=True)
+        assert exc_info.value.exit_code == 1
+
+    def test_unreadable_path_logs_generic_error(
+        self, tmp_path, caplog, mock_ansible_runner
+    ):
+        # Opening a directory raises IsADirectoryError (an OSError, not a
+        # FileNotFoundError), so it falls through to the generic handler.
+        result = main.handle_file(str(tmp_path), dryrun=False, fail_fast=False)
+        assert result is None
+        assert "Error reading file" in caplog.text
+        assert mock_ansible_runner.calls == []
+
+    def test_unreadable_path_fail_fast_exits(self, tmp_path):
+        with pytest.raises(typer.Exit) as exc_info:
+            main.handle_file(str(tmp_path), dryrun=False, fail_fast=True)
+        assert exc_info.value.exit_code == 1
+
+    def test_empty_file_warns_and_returns_even_with_fail_fast(
+        self, tmp_path, caplog, mock_ansible_runner
+    ):
+        # The empty-file branch has no fail_fast exit -- it always returns.
+        file = write_resource_file(tmp_path, "# only a comment\n")
+        result = main.handle_file(file, dryrun=False, fail_fast=True)
+        assert result is None
+        assert "empty or contains only comments" in caplog.text
+        assert mock_ansible_runner.calls == []
+
+    @pytest.mark.parametrize("text,type_name", [("key: value", "dict"), ("42", "int")])
+    def test_non_list_root_logs_actual_type(self, tmp_path, caplog, text, type_name):
+        file = write_resource_file(tmp_path, text)
+        result = main.handle_file(file, dryrun=False, fail_fast=False)
+        assert result is None
+        assert f"Expected a list of tasks, got {type_name}" in caplog.text
+
+    def test_non_list_root_fail_fast_exits(self, tmp_path):
+        file = write_resource_file(tmp_path, "key: value")
+        with pytest.raises(typer.Exit) as exc_info:
+            main.handle_file(file, dryrun=False, fail_fast=True)
+        assert exc_info.value.exit_code == 1
+
+
+class TestHandleFileTaskValidation:
+    """Group 2 -- per-task validation branches."""
+
+    def test_non_dict_task_skipped_and_rest_processed(self, tmp_path, capsys, caplog):
+        text = "- [not, a, dict]\n- debug:\n    msg: kept\n"
+        play = render_playbook(tmp_path, capsys, text)
+        assert "Invalid task structure" in caplog.text
+        assert "at index 0" in caplog.text
+        assert "got list" in caplog.text
+        # The `continue` means the following debug task is still processed.
+        tasks = play["tasks"]
+        assert len(tasks) == 1
+        assert tasks[0] == {"ansible.builtin.debug": {"msg": "kept"}}
+
+    def test_non_dict_task_fail_fast_exits(self, tmp_path):
+        # The inner `raise typer.Exit(1)` is caught by handle_file's outer
+        # `except Exception` (typer.Exit subclasses Exception) and re-raised,
+        # emitting an extra "Error processing tasks" log line. The observable
+        # behaviour is still exit code 1, which is what we pin -- we do not
+        # assert the absence of that extra log line.
+        file = write_resource_file(tmp_path, "- [not, a, dict]\n")
+        with pytest.raises(typer.Exit) as exc_info:
+            main.handle_file(file, dryrun=False, fail_fast=True)
+        assert exc_info.value.exit_code == 1
+
+    def test_empty_task_dict_warns_and_never_exits(self, tmp_path, capsys, caplog):
+        # An empty task warns and skips regardless of fail_fast (no exit branch).
+        text = "- {}\n- debug:\n    msg: kept\n"
+        play = render_playbook(tmp_path, capsys, text, fail_fast=True)
+        assert "Empty task in file" in caplog.text
+        assert "index 0" in caplog.text
+        tasks = play["tasks"]
+        assert len(tasks) == 1
+        assert tasks[0] == {"ansible.builtin.debug": {"msg": "kept"}}
+
+    def test_register_only_task_warns_and_skips(
+        self, tmp_path, caplog, mock_ansible_runner
+    ):
+        # After popping `register` the task is empty, so next(iter(...)) raises
+        # StopIteration -> warn + skip, then the no-tasks gate returns.
+        file = write_resource_file(tmp_path, "- register: out\n")
+        result = main.handle_file(file, dryrun=False)
+        assert result is None
+        assert "no content after removing 'register' field" in caplog.text
+        assert mock_ansible_runner.calls == []
+
+    def test_register_popped_before_first_key_is_read(self, tmp_path, capsys):
+        # `register` is listed first, yet dispatch keys on `vlan` -- proving the
+        # pop (main.py:526) runs before the first remaining key is read
+        # (main.py:530) -- and the popped value flows into the built task.
+        text = "- register: vlan_result\n  vlan:\n    name: OOB\n    vid: 100\n"
+        play = render_playbook(tmp_path, capsys, text)
+        tasks = play["tasks"]
+        assert len(tasks) == 1
+        assert "netbox.netbox.netbox_vlan" in tasks[0]
+        assert tasks[0]["register"] == "vlan_result"
+
+
+class TestHandleFileDispatch:
+    """Group 3 -- per-key dispatch branches."""
+
+    def test_vars_blocks_merge_and_later_wins(self, tmp_path, capsys):
+        text = (
+            "- vars:\n    a: 1\n    nested:\n      x: 1\n"
+            "- vars:\n    nested:\n      x: 2\n"
+            "- debug:\n    msg: hi\n"
+        )
+        play = render_playbook(tmp_path, capsys, text)
+        # deep_merge: later vars win at the leaf, siblings are preserved, and
+        # the merged vars reach the rendered play. No task is emitted for `vars`.
+        assert play["vars"] == {"a": 1, "nested": {"x": 2}}
+        assert len(play["tasks"]) == 1
+
+    def test_debug_task_with_register_and_ignore_errors(self, tmp_path, capsys):
+        text = "- register: r\n  debug:\n    msg: hello\n"
+        play = render_playbook(tmp_path, capsys, text, ignore_errors=True)
+        tasks = play["tasks"]
+        assert len(tasks) == 1
+        assert tasks[0] == {
+            "ansible.builtin.debug": {"msg": "hello"},
+            "register": "r",
+            "ignore_errors": True,
+        }
+
+    def test_debug_task_bare(self, tmp_path, capsys):
+        # No register, default ignore_errors=False: neither key is added.
+        text = "- debug:\n    msg: hello\n"
+        play = render_playbook(tmp_path, capsys, text)
+        tasks = play["tasks"]
+        assert len(tasks) == 1
+        assert set(tasks[0]) == {"ansible.builtin.debug"}
+
+    def test_uri_task_wiring(self, tmp_path, capsys):
+        text = "- register: resp\n  uri:\n    path: /api/status/\n    method: GET\n"
+        play = render_playbook(tmp_path, capsys, text)
+        tasks = play["tasks"]
+        assert len(tasks) == 1
+        uri = tasks[0]["ansible.builtin.uri"]
+        # The value reached the real create_uri_task (URL built from the conftest
+        # baseline); only the wiring is pinned, not the builder internals (#249).
+        assert uri["url"] == "http://localhost:8000/api/status/"
+        assert uri["method"] == "GET"
+        assert tasks[0]["register"] == "resp"
+
+    def test_default_key_builds_netbox_task(self, tmp_path, capsys):
+        text = "- vlan:\n    name: OOB\n    vid: 100\n"
+        play = render_playbook(tmp_path, capsys, text)
+        tasks = play["tasks"]
+        assert len(tasks) == 1
+        module = tasks[0]["netbox.netbox.netbox_vlan"]
+        assert module["data"] == {"name": "OOB", "vid": 100}
+
+    def test_task_filter_keeps_only_matching_type(self, tmp_path, capsys, caplog):
+        caplog.set_level(logging.DEBUG)
+        text = (
+            "- vlan:\n    name: OOB\n    vid: 100\n"
+            "- device_interface:\n    device: node-1\n    name: eth0\n"
+        )
+        # The filter normalises '-' to '_', so 'device-interface' matches.
+        play = render_playbook(tmp_path, capsys, text, task_filter="device-interface")
+        tasks = play["tasks"]
+        assert len(tasks) == 1
+        assert "netbox.netbox.netbox_device_interface" in tasks[0]
+        assert "Skipping task of type 'vlan'" in caplog.text
+
+    def test_device_filter_skips_and_keeps(self, tmp_path, capsys, caplog):
+        caplog.set_level(logging.DEBUG)
+        text = (
+            "- device_interface:\n    device: node-1\n    name: eth0\n"
+            "- device_interface:\n    device: other-2\n    name: eth0\n"
+            "- vlan:\n    name: OOB\n    vid: 100\n"
+        )
+        play = render_playbook(tmp_path, capsys, text, device_filters=["node"])
+        tasks = play["tasks"]
+        assert len(tasks) == 1
+        assert tasks[0]["netbox.netbox.netbox_device_interface"]["data"]["device"] == (
+            "node-1"
+        )
+        # Both device-filter skip branches fire: one task references a
+        # non-matching device, the other references no device at all.
+        assert "Skipping task with devices" in caplog.text
+        assert "no device reference" in caplog.text
+
+    def test_ignore_errors_reaches_all_task_types(self, tmp_path, capsys):
+        text = (
+            "- debug:\n    msg: hi\n"
+            "- uri:\n    path: /status/\n"
+            "- vlan:\n    name: OOB\n"
+        )
+        play = render_playbook(tmp_path, capsys, text, ignore_errors=True)
+        tasks = play["tasks"]
+        assert len(tasks) == 3
+        # Propagates into the debug dict and through both builder calls.
+        assert all(task.get("ignore_errors") is True for task in tasks)
+
+
+class TestHandleFileExecution:
+    """Group 4 -- post-loop / execution branches."""
+
+    def test_task_processing_error_logs_and_returns(
+        self, tmp_path, caplog, mock_ansible_runner
+    ):
+        # A string `uri` value makes create_uri_task's `value.get(...)` raise
+        # AttributeError inside the loop, hitting the outer except.
+        file = write_resource_file(tmp_path, "- uri: not-a-dict\n")
+        result = main.handle_file(file, dryrun=False, fail_fast=False)
+        assert result is None
+        assert "Error processing tasks in file" in caplog.text
+        assert mock_ansible_runner.calls == []
+
+    def test_task_processing_error_fail_fast_exits(self, tmp_path):
+        file = write_resource_file(tmp_path, "- uri: not-a-dict\n")
+        with pytest.raises(typer.Exit) as exc_info:
+            main.handle_file(file, dryrun=False, fail_fast=True)
+        assert exc_info.value.exit_code == 1
+
+    def test_no_tasks_after_filter_skips_playbook(
+        self, tmp_path, caplog, mock_ansible_runner
+    ):
+        caplog.set_level(logging.INFO)
+        # The only task's type does not match the filter -> no tasks remain, so
+        # handle_file returns before rendering or executing anything.
+        file = write_resource_file(tmp_path, "- vlan:\n    name: OOB\n")
+        result = main.handle_file(file, dryrun=False, task_filter="device")
+        assert result is None
+        assert "No tasks to execute" in caplog.text
+        assert "after filtering" in caplog.text
+        assert mock_ansible_runner.calls == []
+
+    def test_show_playbooks_prints_and_never_runs(
+        self, tmp_path, capsys, mock_ansible_runner
+    ):
+        file = write_resource_file(tmp_path, "- debug:\n    msg: hi\n")
+        main.handle_file(file, dryrun=False, show_playbooks=True)
+        out = capsys.readouterr().out
+        assert out.startswith(f"# Playbook for {file}")
+        plays = yaml.safe_load(out)
+        assert len(plays) == 1
+        assert plays[0]["name"] == ("Manage NetBox resources defined in 300-test.yml")
+        assert mock_ansible_runner.calls == []
+
+    def test_dryrun_skips_execution(self, tmp_path, caplog, mock_ansible_runner):
+        caplog.set_level(logging.INFO)
+        file = write_resource_file(tmp_path, "- debug:\n    msg: hi\n")
+        main.handle_file(file, dryrun=True)
+        assert "Skip the execution" in caplog.text
+        assert "only one dry run" in caplog.text
+        assert mock_ansible_runner.calls == []
+
+    def test_run_invocation_kwargs(self, tmp_path, mock_ansible_runner):
+        file = write_resource_file(tmp_path, "- vlan:\n    name: OOB\n    vid: 100\n")
+        main.handle_file(file, dryrun=False, verbose=False)
+        assert len(mock_ansible_runner.calls) == 1
+        kw = mock_ansible_runner.calls[0]
+        assert kw["verbosity"] is None
+        assert kw["envvars"] == {
+            "ANSIBLE_STDOUT_CALLBACK": "ansible.builtin.default",
+            "ANSIBLE_CALLBACKS_ENABLED": "ansible.builtin.default",
+            "ANSIBLE_STDOUT_CALLBACK_RESULT_FORMAT": "yaml",
+        }
+        assert callable(kw["cancel_callback"])
+        assert isinstance(kw["private_data_dir"], str) and kw["private_data_dir"]
+        # inventory is the module-level localhost dict (a kwarg the issue omits).
+        assert kw["inventory"] is main.inventory
+        assert kw["playbook"].endswith(".yml")
+        # The temp playbook is written before run() -- read it back to confirm
+        # the rendered task landed on disk (NamedTemporaryFile(delete=False)).
+        with open(kw["playbook"]) as fp:
+            written = yaml.safe_load(fp)
+        assert "netbox.netbox.netbox_vlan" in written[0]["tasks"][0]
+
+    def test_run_verbose_sets_verbosity_3(self, tmp_path, mock_ansible_runner):
+        file = write_resource_file(tmp_path, "- vlan:\n    name: OOB\n")
+        main.handle_file(file, dryrun=False, verbose=True)
+        assert len(mock_ansible_runner.calls) == 1
+        assert mock_ansible_runner.calls[0]["verbosity"] == 3
+
+    def test_failed_status_with_fail_fast_exits(
+        self, tmp_path, caplog, mock_ansible_runner
+    ):
+        mock_ansible_runner.status = "failed"
+        file = write_resource_file(tmp_path, "- vlan:\n    name: OOB\n")
+        with pytest.raises(typer.Exit) as exc_info:
+            main.handle_file(file, dryrun=False, fail_fast=True)
+        assert exc_info.value.exit_code == 1
+        assert "Ansible playbook failed" in caplog.text
+
+    def test_failed_status_without_fail_fast_returns(
+        self, tmp_path, mock_ansible_runner
+    ):
+        mock_ansible_runner.status = "failed"
+        file = write_resource_file(tmp_path, "- vlan:\n    name: OOB\n")
+        result = main.handle_file(file, dryrun=False, fail_fast=False)
+        assert result is None
+        assert len(mock_ansible_runner.calls) == 1
+
+    def test_successful_status_with_fail_fast_returns(
+        self, tmp_path, mock_ansible_runner
+    ):
+        file = write_resource_file(tmp_path, "- vlan:\n    name: OOB\n")
+        result = main.handle_file(file, dryrun=False, fail_fast=True)
+        assert result is None
+        assert len(mock_ansible_runner.calls) == 1

--- a/tests/unit/netbox_manager/test_handle_file.py
+++ b/tests/unit/netbox_manager/test_handle_file.py
@@ -119,6 +119,9 @@ class TestHandleFileLoadErrors:
         self, tmp_path, caplog, mock_ansible_runner
     ):
         # The empty-file branch has no fail_fast exit -- it always returns.
+        # Characterization, not endorsement: an empty resource file passing
+        # silently under --fail may itself be a bug (see the PR #266 review
+        # note); a future fix that makes this exit is not a regression.
         file = write_resource_file(tmp_path, "# only a comment\n")
         result = main.handle_file(file, dryrun=False, fail_fast=True)
         assert result is None
@@ -166,6 +169,8 @@ class TestHandleFileTaskValidation:
 
     def test_empty_task_dict_warns_and_never_exits(self, tmp_path, capsys, caplog):
         # An empty task warns and skips regardless of fail_fast (no exit branch).
+        # Characterization, not endorsement -- same asymmetry as the empty-file
+        # branch above; see the PR #266 review note.
         text = "- {}\n- debug:\n    msg: kept\n"
         play = render_playbook(tmp_path, capsys, text, fail_fast=True)
         assert "Empty task in file" in caplog.text
@@ -364,10 +369,10 @@ class TestHandleFileExecution:
         # inventory is the module-level localhost dict (a kwarg the issue omits).
         assert kw["inventory"] is main.inventory
         assert kw["playbook"].endswith(".yml")
-        # The temp playbook is written before run() -- read it back to confirm
-        # the rendered task landed on disk (NamedTemporaryFile(delete=False)).
-        with open(kw["playbook"]) as fp:
-            written = yaml.safe_load(fp)
+        # The recorder snapshots the playbook file at run() time, when it is
+        # guaranteed to exist -- reading it back here instead would depend on
+        # the delete=False temp-file leak that #267 removes.
+        written = mock_ansible_runner.playbooks[0]
         assert "netbox.netbox.netbox_vlan" in written[0]["tasks"][0]
 
     def test_run_verbose_sets_verbosity_3(self, tmp_path, mock_ansible_runner):


### PR DESCRIPTION
Closes #252

Tier 4 of the #232 unit-test rollout: branch-test `handle_file` in `netbox_manager/main.py`, the orchestration glue that loads a YAML resource file, validates its structure, dispatches each task to the right builder, applies the task/device filters, renders a playbook, and — unless dry-run or show-playbooks — invokes `ansible_runner.run`.

This is a **test-only** change. No production code is touched.

## Change set (in commit order)

### `99cee8c` Add loguru caplog bridge and ansible_runner recorder fixtures
Adds two shared fixtures to `tests/conftest.py` for the #232 tiers, starting with Tier 4:

- **`caplog` override** — registers pytest's capture handler as a loguru sink for the duration of each test, so tests can assert on the loguru output `netbox_manager.main` emits (pytest's stock `caplog` does not see loguru messages, since loguru does not propagate through the standard `logging` root). This is the recipe from the loguru docs.
- **`mock_ansible_runner` recorder** — swaps `main.ansible_runner` for a fake exposing `.calls` (the kwargs of each `run` call) and a mutable `.status`, so tests can assert *whether* — and *with which kwargs* — playbook execution was reached, without running Ansible.

Both fixtures carry docstrings noting their reuse by the later tiers (#256, #258, #259), and the stale "belongs to later tiers" conftest comment is updated now that the ansible_runner mock exists.

### `ca99794` Add unit tests for handle_file orchestration
Adds `tests/unit/netbox_manager/test_handle_file.py` — 33 tests covering all four branch families of `handle_file`:

- **File load / IO errors:** missing file, malformed YAML (with line/column enrichment), generic read error, empty file, non-list root — pinning both the `fail_fast` exit and the silent-return paths.
- **Per-task validation:** non-dict task (continue, rest still processed), empty task dict, register-only task, and register-popped-before-first-key ordering.
- **Per-key dispatch:** `vars` deep-merge (later wins), `debug`, `uri`, the default NetBox path through both filter gates, filter skips, and `ignore_errors` propagation across task types.
- **Post-loop / execution:** task-processing failure, no-tasks-after-filter, show_playbooks, dry-run, the `ansible_runner.run` kwargs (verbosity/envvars/inventory/playbook), and the failed-status gate.

The tests drive the **real** Tier 2 builders (`create_netbox_task` / `create_uri_task` / `create_ansible_playbook`) and the **real** `load_global_vars`, mocking only `ansible_runner` (shared `mock_ansible_runner`) and the filesystem (`tmp_path`), so they exercise `handle_file`'s own logic rather than re-testing its callees.

## Notes for the reviewer

- No divergence from the issue: the branch delivers the Tier 4 `handle_file` coverage requested in #252, and its scope stays within tests + shared fixtures.
- Where PyYAML error messages are asserted, only stable substrings are pinned — the exact `problem`/`context` wording varies across PyYAML versions.
- An autouse `_no_global_vars` fixture forces `settings.VARS` to `None` so `load_global_vars` stays hermetic if a dev environment exports `NETBOX_MANAGER_VARS`.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) c425ac6 with Claude:claude-opus-4-8_
