### PR TITLE
Clean up rendered playbook temp file

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -595,7 +595,7 @@ def handle_file(
 
     with tempfile.TemporaryDirectory() as temp_dir:
         with tempfile.NamedTemporaryFile(
-            mode="w+", suffix=".yml", delete=False
+            mode="w+", suffix=".yml", delete=False, dir=temp_dir
         ) as temp_file:
             temp_file.write(playbook_resources)
 


### PR DESCRIPTION
## Problem

`handle_file()` renders each resource file's Ansible playbook into a
`NamedTemporaryFile(mode="w+", suffix=".yml", delete=False)` created with **no
`dir=` argument** (`netbox_manager/main.py:597`). As a result the file lands in
the *system* temp directory instead of inside the `TemporaryDirectory` opened
one line above, and `delete=False` means it is never unlinked. Every processed
resource file leaks one `.yml` playbook into the system temp dir for the
lifetime of the process, with no cleanup.

## Fix

Pass `dir=temp_dir` so the temp playbook is created inside the surrounding
`TemporaryDirectory`. It is still written before, and read by
`ansible_runner.run()` during, the open context, and is removed together with
the directory when the `with`-block exits. `delete=False` is retained so the
closed handle stays readable by ansible-runner during the run.

## Verification

- Existing unit suite passes on this branch (`152 passed`).
- Drove `handle_file()` with a stubbed `ansible_runner`: the playbook exists
  during `run()`, resides under the temp directory, and is gone once
  `handle_file()` returns — no `.yml` left in the system temp dir.

## ⚠️ Impact on #266

This bug was surfaced (as pre-existing) by the code review of #266. That PR's
`test_run_invocation_kwargs` reads the rendered playbook back off disk *after*
`handle_file()` returns, which only works **because of this leak**. Once this
fix and #266 converge, that test will break.

The test file and `mock_ansible_runner` fixture do not exist on `main`, so
nothing breaks here — but #266 will need its test adapted before/when it merges
on top of this: have the fake `run()` capture the playbook content *during* the
call, instead of reading it back afterward.

- osism/netbox-manager#266

🤖 Generated with [Claude Code](https://claude.com/claude-code)