### PR TITLE
Add Tier 5 unit tests: loopback / cluster / interface-label / portchannel generators

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,13 +28,18 @@ os.environ.pop("NETBOX_MANAGER_NODE_ROLES", None)
 os.environ.pop("NETBOX_MANAGER_SWITCH_ROLES", None)
 
 # Cross-tier fixtures. The lightweight attribute-bag factories `make_device` /
-# `make_interface` (Tier 1, #247) come first; the heavier `mock_ansible_runner`
-# recorder and the loguru->`caplog` bridge (Tier 4, #252) follow. The Device
-# Type Library seams (Tier 9, #257) -- the fake `pynetbox.api` client
-# (`make_dtl_api`), the `tmp_path` library-tree builder (`make_dtl_tree`), the
-# `LogHandler` call-through spy (`dtl_log_handler`) and the raisable
-# `pynetbox.RequestError` factory (`make_request_error`) -- close the file. The
-# remaining heavy seams (`git.Repo`, `subprocess`) belong to later #232 tiers.
+# `make_interface` (Tier 1, #247) come first; the Tier 5 (#253) generator seams
+# -- the `make_cluster` / `make_config_context` bags and the fake `pynetbox.api`
+# client (`make_netbox_api`, backed by `FakeNetBoxEndpoint`) that the loopback /
+# cluster / interface-label / portchannel generators query -- follow, alongside
+# the `make_device` / `make_interface` keyword extensions those generators read.
+# Next come the heavier `mock_ansible_runner` recorder and the loguru->`caplog`
+# bridge (Tier 4, #252). The Device Type Library seams (Tier 9, #257) -- the
+# fake `pynetbox.api` client (`make_dtl_api`), the `tmp_path` library-tree
+# builder (`make_dtl_tree`), the `LogHandler` call-through spy
+# (`dtl_log_handler`) and the raisable `pynetbox.RequestError` factory
+# (`make_request_error`) -- close the file. The remaining heavy seams
+# (`git.Repo`, `subprocess`) belong to later #232 tiers.
 
 
 @pytest.fixture
@@ -54,9 +59,19 @@ def make_device():
         device_type_model: ``model`` for ``device.device_type``; when omitted
             ``device.device_type`` is ``None``.
         custom_fields: Mapping for ``device.custom_fields`` (defaults to ``{}``).
+        device_id: ``device.id`` -- the value the generators pass as
+            ``dcim.interfaces.filter(device_id=...)`` (defaults to ``None``).
+        cluster: ``device.cluster`` -- a ``make_cluster`` object (or ``None``,
+            the default, for a device with no cluster). Always present as an
+            attribute so ``_generate_cluster_loopback_tasks``' direct
+            ``device.cluster`` read never raises ``AttributeError``.
+        position: ``device.position`` -- the rack position
+            ``calculate_loopback_ips`` reads (defaults to ``None``).
 
-    Shared with later #232 test tiers; extend it here rather than re-deriving
-    device shapes per test module.
+    The Tier 5 generator tests (#253) read ``id`` / ``cluster`` / ``position``;
+    the Tier 1 helper tests (#247) predate them and pass none of the three, so
+    every one is keyword-only with a benign default. Shared with later #232 test
+    tiers; extend it here rather than re-deriving device shapes per test module.
     """
 
     def _make_device(
@@ -66,6 +81,9 @@ def make_device():
         role_name=None,
         device_type_model=None,
         custom_fields=None,
+        device_id=None,
+        cluster=None,
+        position=None,
     ):
         if role_slug is None and role_name is None:
             role = None
@@ -87,6 +105,9 @@ def make_device():
             role=role,
             device_type=device_type,
             custom_fields={} if custom_fields is None else custom_fields,
+            id=device_id,
+            cluster=cluster,
+            position=position,
         )
 
     return _make_device
@@ -97,14 +118,42 @@ def make_interface():
     """Build interface-like attribute bags for the pure-logic helpers.
 
     Returns a factory producing a :class:`types.SimpleNamespace` that exposes
-    only ``type`` (with ``value`` / ``label``), which is all
-    :func:`netbox_manager.main.is_virtual_interface` reads. When neither
-    ``type_value`` nor ``type_label`` is given, ``type`` is ``None``.
+    ``type`` (with ``value`` / ``label``, all
+    :func:`netbox_manager.main.is_virtual_interface` reads) plus the attributes
+    the Tier 5 generators (#253) read off a ``dcim.interfaces.filter(...)``
+    record. When neither ``type_value`` nor ``type_label`` is given, ``type`` is
+    ``None``.
+
+    Keyword arguments of the factory:
+        type_value / type_label: Attributes for ``interface.type``.
+        name: ``interface.name`` -- the port name emitted into label / member
+            tasks and read off a connected endpoint (defaults to ``None``).
+        interface_id: ``interface.id`` -- the identity the PortChannel dedup
+            matches connections on (defaults to ``None``).
+        cable: ``interface.cable`` -- a truthy value marks the port cabled;
+            ``None`` (the default) exercises the not-cabled skip branch.
+        connected_endpoints: ``interface.connected_endpoints`` -- a list of
+            endpoint records (each itself an interface bag exposing ``device`` /
+            ``name`` / ``id``); ``None`` (the default) exercises the
+            no-endpoints skip branch.
+        device: ``interface.device`` -- the device the port lives on. Set on an
+            interface used as a connected endpoint so the generator can read the
+            far-side device back off it (mirrors a real NetBox record); ``None``
+            (the default) exercises the endpoint-without-device skip branch.
 
     Shared with later #232 test tiers.
     """
 
-    def _make_interface(*, type_value=None, type_label=None):
+    def _make_interface(
+        *,
+        type_value=None,
+        type_label=None,
+        name=None,
+        interface_id=None,
+        cable=None,
+        connected_endpoints=None,
+        device=None,
+    ):
         if type_value is None and type_label is None:
             interface_type = None
         else:
@@ -113,9 +162,155 @@ def make_interface():
                 interface_type.value = type_value
             if type_label is not None:
                 interface_type.label = type_label
-        return SimpleNamespace(type=interface_type)
+        return SimpleNamespace(
+            type=interface_type,
+            name=name,
+            id=interface_id,
+            cable=cable,
+            connected_endpoints=connected_endpoints,
+            device=device,
+        )
 
     return _make_interface
+
+
+@pytest.fixture
+def make_cluster():
+    """Build cluster-like attribute bags for the loopback / label generators.
+
+    ``make_cluster(cluster_id=1, name="segment-a")`` returns a
+    :class:`types.SimpleNamespace` exposing the two attributes the generators
+    read off ``device.cluster`` -- ``id`` (the key
+    :func:`netbox_manager.main.group_devices_by_cluster` buckets by and the
+    value passed to ``extras.config_contexts.filter(clusters=...)``) and
+    ``name`` (matched against ``ctx.name`` to select the segment context).
+    Shared with later mock-heavy #232 tiers (#254, #255).
+    """
+
+    def _make_cluster(*, cluster_id=1, name="segment-a"):
+        return SimpleNamespace(id=cluster_id, name=name)
+
+    return _make_cluster
+
+
+@pytest.fixture
+def make_config_context():
+    """Build config-context-like attribute bags for the loopback generators.
+
+    ``make_config_context(name="segment-a", data={...})`` returns a
+    :class:`types.SimpleNamespace` exposing the two attributes
+    :func:`netbox_manager.main._get_cluster_segment_config_context` reads off an
+    ``extras.config_contexts.filter(...)`` record -- ``name`` (matched against
+    the cluster name) and ``data`` (the config dict returned verbatim, or a
+    falsy value to drive the no-data branch). Shared with later mock-heavy #232
+    tiers (#254, #255).
+    """
+
+    def _make_config_context(*, name="segment-a", data=None):
+        return SimpleNamespace(name=name, data=data)
+
+    return _make_config_context
+
+
+class FakeNetBoxEndpoint:
+    """Recording stand-in for a pynetbox API endpoint used by the generators.
+
+    Mirrors :class:`FakeDtlEndpoint` but for the read-only shape the Tier 5
+    generators (#253) touch: ``all()`` and ``filter(**kwargs)``. Behaviour is
+    configured at construction and every call is recorded for assertions:
+
+        all_result: records ``all()`` returns (default empty).
+        filter_lookup: callable mapping the ``filter(**kwargs)`` kwargs dict to
+            the records that call returns (default: always ``[]``). Used for the
+            ``dcim.interfaces.filter(device_id=...)`` and
+            ``extras.config_contexts.filter(clusters=...)`` seams.
+        filter_error: when set, ``filter(...)`` raises it -- drives the
+            defensive ``except`` in ``_get_cluster_segment_config_context``.
+        all_calls: number of ``all()`` calls.
+        filter_calls: list of the keyword dicts passed to ``filter(...)`` (assert
+            the generator queried the expected ``device_id`` / ``clusters``).
+    """
+
+    def __init__(self, *, all_result=None, filter_lookup=None, filter_error=None):
+        self._all_result = [] if all_result is None else list(all_result)
+        self._filter_lookup = filter_lookup
+        self.filter_error = filter_error
+        self.all_calls = 0
+        self.filter_calls = []
+
+    def all(self):
+        self.all_calls += 1
+        return list(self._all_result)
+
+    def filter(self, **kwargs):
+        self.filter_calls.append(kwargs)
+        if self.filter_error is not None:
+            raise self.filter_error
+        if self._filter_lookup is None:
+            return []
+        return list(self._filter_lookup(kwargs))
+
+
+@pytest.fixture
+def make_netbox_api():
+    """Return a factory building a fake ``pynetbox.api`` client for generators.
+
+    First materialised here for #253; the loopback / cluster / interface-label /
+    portchannel generators in :mod:`netbox_manager.main` each call
+    ``create_netbox_api()`` internally, so wire the returned object in with
+    ``monkeypatch.setattr(main, "create_netbox_api", lambda: fake_api)``.
+
+    ``make_netbox_api(...)`` returns a :class:`types.SimpleNamespace` exposing
+    exactly the three endpoints the generators read, each a
+    :class:`FakeNetBoxEndpoint` recording its calls:
+
+        dcim.devices.all(): returns ``devices``.
+        dcim.interfaces.filter(device_id=...): returns
+            ``interfaces_by_device.get(device_id, [])``.
+        extras.config_contexts.filter(clusters=...): returns
+            ``config_contexts_by_cluster.get(clusters, [])``, or raises
+            ``config_contexts_error`` when that is set.
+
+    Seed the endpoints with the ``make_device`` / ``make_interface`` /
+    ``make_cluster`` / ``make_config_context`` bags (whose attributes match what
+    each generator reads: ``device.cluster`` / ``device.position`` /
+    ``device.custom_fields`` / ``device.device_type.model``, ``interface.cable``
+    / ``interface.connected_endpoints`` with ``endpoint.device`` /
+    ``endpoint.name``, and ``ctx.name`` / ``ctx.data``). Reach into the returned
+    object (e.g. ``fake_api.dcim.interfaces.filter_calls``) to assert which
+    devices were queried. Shared with the autoconf / validation and later
+    mock-heavy #232 tiers (Tiers 6-9: #254, #255, #256, #258).
+    """
+
+    def _make(
+        *,
+        devices=None,
+        interfaces_by_device=None,
+        config_contexts_by_cluster=None,
+        config_contexts_error=None,
+    ):
+        interfaces_by_device = interfaces_by_device or {}
+        config_contexts_by_cluster = config_contexts_by_cluster or {}
+        return SimpleNamespace(
+            dcim=SimpleNamespace(
+                devices=FakeNetBoxEndpoint(all_result=devices),
+                interfaces=FakeNetBoxEndpoint(
+                    filter_lookup=lambda kw: interfaces_by_device.get(
+                        kw.get("device_id"), []
+                    )
+                ),
+            ),
+            extras=SimpleNamespace(
+                config_contexts=FakeNetBoxEndpoint(
+                    filter_lookup=lambda kw: config_contexts_by_cluster.get(
+                        kw.get("clusters"), []
+                    ),
+                    filter_error=config_contexts_error,
+                ),
+            ),
+        )
+
+    return _make
 
 
 @pytest.fixture

--- a/tests/unit/netbox_manager/test_cluster_loopbacks.py
+++ b/tests/unit/netbox_manager/test_cluster_loopbacks.py
@@ -1,0 +1,443 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the cluster loopback pipeline (issue #253, groups 2-5).
+
+Covers, in order:
+
+* ``_get_cluster_segment_config_context`` -- segment-context lookup by name
+  (group 2), driven through the fake ``pynetbox.api`` passed as its
+  ``netbox_api`` parameter.
+* ``group_devices_by_cluster`` -- pure bucketing by ``device.cluster.id``
+  (group 3).
+* ``calculate_loopback_ips`` -- pure IPv4/IPv6 loopback arithmetic with exact
+  address strings (group 4).
+* ``_generate_cluster_loopback_tasks`` -- the end-to-end generator wired to the
+  fake API via ``create_netbox_api`` (group 5).
+
+The loopback-gate and role helpers are covered in ``test_loopback_gate.py`` and
+``test_helpers.py`` (Tier 1, #247); only their effect inside the generator is
+asserted here.
+"""
+
+import ipaddress
+from types import SimpleNamespace
+
+import pytest
+
+from netbox_manager import main
+
+IPV4_NETWORK = ipaddress.IPv4Network("10.10.128.0/24")
+IPV6_NETWORK = ipaddress.IPv6Network("fd93:363d:dab8::/64")
+
+
+class TestGetClusterSegmentConfigContext:
+    """``_get_cluster_segment_config_context`` selects the context by name."""
+
+    def test_name_match_returns_data_verbatim(
+        self, make_netbox_api, make_config_context
+    ):
+        # Data carries _segment_loopback_network_ipv4, so the debug branch runs;
+        # the returned object is the context's own data dict, unchanged.
+        data = {
+            "_segment_loopback_network_ipv4": "10.10.128.0/24",
+            "_segment_loopback_network_ipv6": "fd93:363d:dab8::/64",
+            "extra": 1,
+        }
+        ctx = make_config_context(name="seg-a", data=data)
+        fake_api = make_netbox_api(config_contexts_by_cluster={7: [ctx]})
+
+        result = main._get_cluster_segment_config_context(fake_api, 7, "seg-a")
+
+        assert result is data
+
+    def test_name_match_without_loopback_key_still_returns_data(
+        self, make_netbox_api, make_config_context
+    ):
+        # The debug branch is skipped (no _segment_loopback_network_ipv4) but the
+        # data dict is still returned verbatim.
+        data = {"some_other_key": "value"}
+        ctx = make_config_context(name="seg-a", data=data)
+        fake_api = make_netbox_api(config_contexts_by_cluster={7: [ctx]})
+
+        assert main._get_cluster_segment_config_context(fake_api, 7, "seg-a") is data
+
+    @pytest.mark.parametrize("falsy_data", [None, {}])
+    def test_name_match_with_falsy_data_returns_empty(
+        self, make_netbox_api, make_config_context, falsy_data
+    ):
+        ctx = make_config_context(name="seg-a", data=falsy_data)
+        fake_api = make_netbox_api(config_contexts_by_cluster={7: [ctx]})
+
+        assert main._get_cluster_segment_config_context(fake_api, 7, "seg-a") == {}
+
+    def test_no_name_match_returns_empty_and_filters_by_cluster_id(
+        self, make_netbox_api, make_config_context
+    ):
+        # A differently-named context in first position proves selection is by
+        # name, not by filter position.
+        ctx = make_config_context(name="other-segment", data={"x": 1})
+        fake_api = make_netbox_api(config_contexts_by_cluster={7: [ctx]})
+
+        assert main._get_cluster_segment_config_context(fake_api, 7, "seg-a") == {}
+        assert fake_api.extras.config_contexts.filter_calls == [{"clusters": 7}]
+
+    def test_lookup_exception_returns_empty(self, make_netbox_api):
+        fake_api = make_netbox_api(config_contexts_error=RuntimeError("boom"))
+
+        assert main._get_cluster_segment_config_context(fake_api, 7, "seg-a") == {}
+
+
+class TestGroupDevicesByCluster:
+    """``group_devices_by_cluster`` buckets devices by ``cluster.id``."""
+
+    def test_same_cluster_accumulates_in_order(self, make_device, make_cluster):
+        # Two cluster objects sharing an id but distinct identities: the bucket
+        # must keep the first-seen object.
+        first = make_cluster(cluster_id=1, name="seg-a")
+        second = make_cluster(cluster_id=1, name="seg-a-dup")
+        d0 = make_device(name="d0", cluster=first)
+        d1 = make_device(name="d1", cluster=second)
+
+        result = main.group_devices_by_cluster([d0, d1])
+
+        assert set(result) == {1}
+        assert result[1]["devices"] == [d0, d1]
+        assert result[1]["cluster"] is first
+
+    def test_distinct_clusters_produce_distinct_buckets(
+        self, make_device, make_cluster
+    ):
+        c1 = make_cluster(cluster_id=1)
+        c2 = make_cluster(cluster_id=2)
+        d0 = make_device(name="d0", cluster=c1)
+        d1 = make_device(name="d1", cluster=c2)
+
+        result = main.group_devices_by_cluster([d0, d1])
+
+        assert set(result) == {1, 2}
+        assert result[1]["devices"] == [d0]
+        assert result[2]["devices"] == [d1]
+        assert result[1]["cluster"] is c1
+        assert result[2]["cluster"] is c2
+
+    def test_empty_input_returns_empty_dict(self):
+        assert main.group_devices_by_cluster([]) == {}
+
+
+class TestCalculateLoopbackIps:
+    """``calculate_loopback_ips`` maps a rack position to loopback addresses."""
+
+    def test_position_none_returns_none_pair(self, make_device):
+        device = make_device(name="d0", position=None)
+        assert main.calculate_loopback_ips(device, IPV4_NETWORK, None, 0) == (
+            None,
+            None,
+        )
+
+    def test_string_position_is_coerced(self, make_device):
+        # "10" -> int 10; byte_4 = 10 * 2 - 1 + 0 = 19.
+        device = make_device(name="d0", position="10")
+        assert main.calculate_loopback_ips(device, IPV4_NETWORK, None, 0) == (
+            "10.10.128.19/32",
+            None,
+        )
+
+    def test_non_convertible_position_returns_none_pair(self, make_device):
+        device = make_device(name="d0", position="abc")
+        assert main.calculate_loopback_ips(device, IPV4_NETWORK, None, 0) == (
+            None,
+            None,
+        )
+
+    def test_default_multiplicator_ipv4_only(self, make_device):
+        # byte_4 = 3 * 2 - 1 + 0 = 5.
+        device = make_device(name="d0", position=3)
+        assert main.calculate_loopback_ips(device, IPV4_NETWORK, None, 0) == (
+            "10.10.128.5/32",
+            None,
+        )
+
+    def test_non_default_multiplicator_and_offset(self, make_device):
+        # byte_4 = 3 * 4 - 1 + 10 = 21.
+        device = make_device(name="d0", position=3)
+        assert main.calculate_loopback_ips(
+            device, IPV4_NETWORK, None, 10, multiplicator=4
+        ) == ("10.10.128.21/32", None)
+
+    def test_ipv6_suffix_mapping(self, make_device):
+        # The four IPv4 octets (10.10.128.5) become the a:b:c:d suffix appended
+        # to the ::-stripped network prefix.
+        device = make_device(name="d0", position=3)
+        assert main.calculate_loopback_ips(device, IPV4_NETWORK, IPV6_NETWORK, 0) == (
+            "10.10.128.5/32",
+            "fd93:363d:dab8:0:10:10:128:5/128",
+        )
+
+    def test_ipv4_arithmetic_error_returns_none_pair(self, make_device):
+        # A network object without ``network_address`` makes the IPv4 arithmetic
+        # raise; the outer except returns (None, None).
+        device = make_device(name="d0", position=3)
+        assert main.calculate_loopback_ips(device, None, IPV6_NETWORK, 0) == (
+            None,
+            None,
+        )
+
+    def test_ipv6_mapping_error_keeps_ipv4(self, make_device):
+        # A truthy IPv6 stand-in without ``network_address`` makes only the inner
+        # IPv6 mapping raise; the IPv4 result survives.
+        device = make_device(name="d0", position=3)
+        assert main.calculate_loopback_ips(
+            device, IPV4_NETWORK, SimpleNamespace(), 0
+        ) == ("10.10.128.5/32", None)
+
+
+@pytest.fixture
+def roles(monkeypatch):
+    """Pin NODE_ROLES / SWITCH_ROLES so loopback eligibility is unambiguous."""
+    monkeypatch.setattr(main.settings, "NODE_ROLES", ["control"], raising=False)
+    monkeypatch.setattr(main.settings, "SWITCH_ROLES", ["leaf"], raising=False)
+
+
+def _wire(monkeypatch, make_netbox_api, *, devices, config_contexts_by_cluster=None):
+    """Point ``main.create_netbox_api`` at a fake API for the cluster generator."""
+    fake_api = make_netbox_api(
+        devices=devices, config_contexts_by_cluster=config_contexts_by_cluster
+    )
+    monkeypatch.setattr(main, "create_netbox_api", lambda: fake_api)
+    return fake_api
+
+
+def _ip_task(address, device):
+    return {
+        "ip_address": {
+            "address": address,
+            "assigned_object": {"name": "Loopback0", "device": device},
+        }
+    }
+
+
+class TestGenerateClusterLoopbackTasks:
+    """``_generate_cluster_loopback_tasks`` emits per-device loopback IPs."""
+
+    def test_happy_path_ipv4_and_ipv6_in_device_order(
+        self, roles, monkeypatch, make_netbox_api, make_device, make_cluster
+    ):
+        cluster = make_cluster(cluster_id=1, name="seg-a")
+        devices = [
+            make_device(
+                name="node-3", role_slug="control", cluster=cluster, position=3
+            ),
+            make_device(
+                name="node-4", role_slug="control", cluster=cluster, position=4
+            ),
+            # A cluster-less device must be filtered out before grouping.
+            make_device(
+                name="no-cluster", role_slug="control", cluster=None, position=9
+            ),
+        ]
+        ctx = SimpleNamespace(
+            name="seg-a",
+            data={
+                "_segment_loopback_network_ipv4": "10.10.128.0/24",
+                "_segment_loopback_network_ipv6": "fd93:363d:dab8::/64",
+            },
+        )
+        _wire(
+            monkeypatch,
+            make_netbox_api,
+            devices=devices,
+            config_contexts_by_cluster={1: [ctx]},
+        )
+
+        result = main._generate_cluster_loopback_tasks()
+
+        assert result == {
+            "ip_address": [
+                _ip_task("10.10.128.5/32", "node-3"),
+                _ip_task("fd93:363d:dab8:0:10:10:128:5/128", "node-3"),
+                _ip_task("10.10.128.7/32", "node-4"),
+                _ip_task("fd93:363d:dab8:0:10:10:128:7/128", "node-4"),
+            ]
+        }
+
+    def test_empty_config_context_skips_cluster(
+        self, roles, monkeypatch, make_netbox_api, make_device, make_cluster
+    ):
+        cluster = make_cluster(cluster_id=1, name="seg-a")
+        devices = [
+            make_device(name="node-3", role_slug="control", cluster=cluster, position=3)
+        ]
+        ctx = SimpleNamespace(name="seg-a", data={})
+        _wire(
+            monkeypatch,
+            make_netbox_api,
+            devices=devices,
+            config_contexts_by_cluster={1: [ctx]},
+        )
+
+        assert main._generate_cluster_loopback_tasks() == {"ip_address": []}
+
+    def test_context_without_ipv4_network_skips_cluster(
+        self, roles, monkeypatch, make_netbox_api, make_device, make_cluster
+    ):
+        cluster = make_cluster(cluster_id=1, name="seg-a")
+        devices = [
+            make_device(name="node-3", role_slug="control", cluster=cluster, position=3)
+        ]
+        ctx = SimpleNamespace(
+            name="seg-a", data={"_segment_loopback_network_ipv6": "fd93:363d:dab8::/64"}
+        )
+        _wire(
+            monkeypatch,
+            make_netbox_api,
+            devices=devices,
+            config_contexts_by_cluster={1: [ctx]},
+        )
+
+        assert main._generate_cluster_loopback_tasks() == {"ip_address": []}
+
+    def test_offset_and_multiplicator_are_honored(
+        self, roles, monkeypatch, make_netbox_api, make_device, make_cluster
+    ):
+        cluster = make_cluster(cluster_id=1, name="seg-a")
+        devices = [
+            make_device(name="node-3", role_slug="control", cluster=cluster, position=3)
+        ]
+        ctx = SimpleNamespace(
+            name="seg-a",
+            data={
+                "_segment_loopback_network_ipv4": "10.10.128.0/24",
+                "_segment_loopback_offset_ipv4": 10,
+                "_segment_loopback_network_multiplicator": 4,
+            },
+        )
+        _wire(
+            monkeypatch,
+            make_netbox_api,
+            devices=devices,
+            config_contexts_by_cluster={1: [ctx]},
+        )
+
+        # byte_4 = 3 * 4 - 1 + 10 = 21.
+        assert main._generate_cluster_loopback_tasks() == {
+            "ip_address": [_ip_task("10.10.128.21/32", "node-3")]
+        }
+
+    def test_invalid_ipv4_network_skips_cluster(
+        self, roles, monkeypatch, make_netbox_api, make_device, make_cluster
+    ):
+        cluster = make_cluster(cluster_id=1, name="seg-a")
+        devices = [
+            make_device(name="node-3", role_slug="control", cluster=cluster, position=3)
+        ]
+        ctx = SimpleNamespace(
+            name="seg-a", data={"_segment_loopback_network_ipv4": "not-a-network"}
+        )
+        _wire(
+            monkeypatch,
+            make_netbox_api,
+            devices=devices,
+            config_contexts_by_cluster={1: [ctx]},
+        )
+
+        assert main._generate_cluster_loopback_tasks() == {"ip_address": []}
+
+    def test_invalid_ipv6_network_drops_ipv6_keeps_ipv4(
+        self, roles, monkeypatch, make_netbox_api, make_device, make_cluster
+    ):
+        cluster = make_cluster(cluster_id=1, name="seg-a")
+        devices = [
+            make_device(name="node-3", role_slug="control", cluster=cluster, position=3)
+        ]
+        ctx = SimpleNamespace(
+            name="seg-a",
+            data={
+                "_segment_loopback_network_ipv4": "10.10.128.0/24",
+                "_segment_loopback_network_ipv6": "not-a-network",
+            },
+        )
+        _wire(
+            monkeypatch,
+            make_netbox_api,
+            devices=devices,
+            config_contexts_by_cluster={1: [ctx]},
+        )
+
+        assert main._generate_cluster_loopback_tasks() == {
+            "ip_address": [_ip_task("10.10.128.5/32", "node-3")]
+        }
+
+    def test_ineligible_device_in_eligible_cluster_is_skipped(
+        self, roles, monkeypatch, make_netbox_api, make_device, make_cluster
+    ):
+        cluster = make_cluster(cluster_id=1, name="seg-a")
+        devices = [
+            make_device(
+                name="node-3", role_slug="control", cluster=cluster, position=3
+            ),
+            # Switch role without SONiC hwsku: ineligible for a Loopback0.
+            make_device(name="leaf-0", role_slug="leaf", cluster=cluster, position=5),
+        ]
+        ctx = SimpleNamespace(
+            name="seg-a", data={"_segment_loopback_network_ipv4": "10.10.128.0/24"}
+        )
+        _wire(
+            monkeypatch,
+            make_netbox_api,
+            devices=devices,
+            config_contexts_by_cluster={1: [ctx]},
+        )
+
+        assert main._generate_cluster_loopback_tasks() == {
+            "ip_address": [_ip_task("10.10.128.5/32", "node-3")]
+        }
+
+    def test_device_without_position_emits_nothing(
+        self, roles, monkeypatch, make_netbox_api, make_device, make_cluster
+    ):
+        cluster = make_cluster(cluster_id=1, name="seg-a")
+        devices = [
+            make_device(
+                name="node-x", role_slug="control", cluster=cluster, position=None
+            )
+        ]
+        ctx = SimpleNamespace(
+            name="seg-a", data={"_segment_loopback_network_ipv4": "10.10.128.0/24"}
+        )
+        _wire(
+            monkeypatch,
+            make_netbox_api,
+            devices=devices,
+            config_contexts_by_cluster={1: [ctx]},
+        )
+
+        assert main._generate_cluster_loopback_tasks() == {"ip_address": []}
+
+    def test_per_cluster_exception_is_swallowed_and_next_cluster_processed(
+        self, roles, monkeypatch, make_netbox_api, make_device, make_cluster, mocker
+    ):
+        cluster_a = make_cluster(cluster_id=1, name="seg-a")
+        cluster_b = make_cluster(cluster_id=2, name="seg-b")
+        devices = [
+            make_device(
+                name="node-a", role_slug="control", cluster=cluster_a, position=3
+            ),
+            make_device(
+                name="node-b", role_slug="control", cluster=cluster_b, position=3
+            ),
+        ]
+        _wire(monkeypatch, make_netbox_api, devices=devices)
+        # The real helper swallows its own errors, so patch it to raise for the
+        # first cluster and return a valid context for the second.
+        mocker.patch.object(
+            main,
+            "_get_cluster_segment_config_context",
+            side_effect=[
+                RuntimeError("boom"),
+                {"_segment_loopback_network_ipv4": "10.10.128.0/24"},
+            ],
+        )
+
+        assert main._generate_cluster_loopback_tasks() == {
+            "ip_address": [_ip_task("10.10.128.5/32", "node-b")]
+        }

--- a/tests/unit/netbox_manager/test_interface_label_generation.py
+++ b/tests/unit/netbox_manager/test_interface_label_generation.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``_generate_device_interface_labels`` (issue #253, group 6).
+
+The generator selects switch / router / firewall source devices that resolve a
+non-empty interface label, walks each source interface's connected endpoints,
+and emits a ``device_interface`` label task for every endpoint that lands on a
+node interface. The label-resolution helper (``_resolve_device_interface_label``)
+and the disambiguation helper (``_disambiguate_interface_labels``) have their own
+Tier 1 / #243 / #220 coverage; here only their effect inside the generator is
+asserted. Roles are pinned via ``main.settings`` -- crucially NODE_ROLES is set
+to a list that excludes ``router`` / ``firewall`` (which the in-module defaults
+treat as node roles) so source-vs-node selection is unambiguous.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from netbox_manager import main
+
+
+@pytest.fixture
+def roles(monkeypatch):
+    """Pin roles so ``router`` / ``firewall`` are sources, not nodes."""
+    monkeypatch.setattr(main.settings, "NODE_ROLES", ["control"], raising=False)
+    monkeypatch.setattr(main.settings, "SWITCH_ROLES", ["leaf"], raising=False)
+
+
+def _wire(
+    monkeypatch,
+    make_netbox_api,
+    *,
+    devices,
+    interfaces_by_device=None,
+    config_contexts_by_cluster=None,
+):
+    """Point ``main.create_netbox_api`` at a fake API for the label generator."""
+    fake_api = make_netbox_api(
+        devices=devices,
+        interfaces_by_device=interfaces_by_device,
+        config_contexts_by_cluster=config_contexts_by_cluster,
+    )
+    monkeypatch.setattr(main, "create_netbox_api", lambda: fake_api)
+    return fake_api
+
+
+def _label_task(device, name, label, custom_fields=None):
+    task = {
+        "device": device,
+        "name": name,
+        "label": label,
+        "tags": ["managed-by-osism"],
+    }
+    if custom_fields is not None:
+        task["custom_fields"] = custom_fields
+    return {"device_interface": task}
+
+
+def test_emits_label_task_for_node_endpoint(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    node = make_device(name="node-0", role_slug="control")
+    endpoint = make_interface(name="Ethernet5", device=node)
+    source_iface = make_interface(name="Ethernet1", connected_endpoints=[endpoint])
+    source = make_device(
+        name="switch-0",
+        role_slug="leaf",
+        device_id=10,
+        custom_fields={"device_interface_label": "data1"},
+    )
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[source, node],
+        interfaces_by_device={10: [source_iface]},
+    )
+
+    tasks = main._generate_device_interface_labels()
+
+    assert tasks == [_label_task("node-0", "Ethernet5", "data1")]
+
+
+@pytest.mark.parametrize("role_slug", ["router", "firewall"])
+def test_router_and_firewall_are_sources(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface, role_slug
+):
+    node = make_device(name="node-0", role_slug="control")
+    endpoint = make_interface(name="Ethernet5", device=node)
+    source_iface = make_interface(name="Ethernet1", connected_endpoints=[endpoint])
+    source = make_device(
+        name="src",
+        role_slug=role_slug,
+        device_id=20,
+        custom_fields={"device_interface_label": "data1"},
+    )
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[source, node],
+        interfaces_by_device={20: [source_iface]},
+    )
+
+    assert main._generate_device_interface_labels() == [
+        _label_task("node-0", "Ethernet5", "data1")
+    ]
+
+
+def test_node_role_device_is_never_a_source(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    # A node-role device carrying a label and a connection must not act as a
+    # source (only switches / routers / firewalls do).
+    other_node = make_device(name="node-1", role_slug="control")
+    endpoint = make_interface(name="Ethernet5", device=other_node)
+    node_iface = make_interface(name="Ethernet1", connected_endpoints=[endpoint])
+    node = make_device(
+        name="node-0",
+        role_slug="control",
+        device_id=30,
+        custom_fields={"device_interface_label": "data1"},
+    )
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[node, other_node],
+        interfaces_by_device={30: [node_iface]},
+    )
+
+    assert main._generate_device_interface_labels() == []
+
+
+def test_segment_config_context_provides_label(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface, make_cluster
+):
+    # Empty custom fields but a cluster whose segment context carries the label:
+    # integration through the real _resolve_device_interface_label +
+    # _get_cluster_segment_config_context.
+    node = make_device(name="node-0", role_slug="control")
+    endpoint = make_interface(name="Ethernet5", device=node)
+    source_iface = make_interface(name="Ethernet1", connected_endpoints=[endpoint])
+    cluster = make_cluster(cluster_id=5, name="seg-x")
+    source = make_device(
+        name="switch-0", role_slug="leaf", device_id=10, cluster=cluster
+    )
+    ctx = SimpleNamespace(
+        name="seg-x", data={"_segment_device_interface_label": "seg1"}
+    )
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[source, node],
+        interfaces_by_device={10: [source_iface]},
+        config_contexts_by_cluster={5: [ctx]},
+    )
+
+    assert main._generate_device_interface_labels() == [
+        _label_task("node-0", "Ethernet5", "seg1")
+    ]
+
+
+def test_source_without_label_emits_nothing_and_is_not_queried(
+    roles, monkeypatch, make_netbox_api, make_device
+):
+    # Switch role but no label from any source: never becomes a source device,
+    # so its interfaces are never fetched.
+    source = make_device(name="switch-0", role_slug="leaf", device_id=10)
+    fake_api = _wire(monkeypatch, make_netbox_api, devices=[source])
+
+    assert main._generate_device_interface_labels() == []
+    assert fake_api.dcim.interfaces.filter_calls == []
+
+
+def test_frr_local_pref_is_added_to_task(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    node = make_device(name="node-0", role_slug="control")
+    endpoint = make_interface(name="Ethernet5", device=node)
+    source_iface = make_interface(name="Ethernet1", connected_endpoints=[endpoint])
+    source = make_device(
+        name="switch-0",
+        role_slug="leaf",
+        device_id=10,
+        custom_fields={"device_interface_label": "data1", "frr_local_pref": 200},
+    )
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[source, node],
+        interfaces_by_device={10: [source_iface]},
+    )
+
+    assert main._generate_device_interface_labels() == [
+        _label_task("node-0", "Ethernet5", "data1", {"frr_local_pref": 200})
+    ]
+
+
+@pytest.mark.parametrize(
+    "endpoint_kwargs, iface_kwargs, description",
+    [
+        (None, {"connected_endpoints": None}, "no connected endpoints"),
+        ({"name": "Ethernet5", "device_role": None}, {}, "endpoint without device"),
+        ({"name": "Ethernet5", "device_role": "leaf"}, {}, "non-node endpoint device"),
+        ({"name": None, "device_role": "control"}, {}, "endpoint without name"),
+    ],
+)
+def test_skip_branches_emit_no_task(
+    roles,
+    monkeypatch,
+    make_netbox_api,
+    make_device,
+    make_interface,
+    endpoint_kwargs,
+    iface_kwargs,
+    description,
+):
+    if endpoint_kwargs is None:
+        # The interface itself has no connected endpoints.
+        source_iface = make_interface(name="Ethernet1", **iface_kwargs)
+    else:
+        far_role = endpoint_kwargs["device_role"]
+        far_device = (
+            make_device(name="far-0", role_slug=far_role)
+            if far_role is not None
+            else None
+        )
+        endpoint = make_interface(name=endpoint_kwargs["name"], device=far_device)
+        source_iface = make_interface(
+            name="Ethernet1", connected_endpoints=[endpoint], **iface_kwargs
+        )
+
+    source = make_device(
+        name="switch-0",
+        role_slug="leaf",
+        device_id=10,
+        custom_fields={"device_interface_label": "data1"},
+    )
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[source],
+        interfaces_by_device={10: [source_iface]},
+    )
+
+    assert main._generate_device_interface_labels() == [], description
+
+
+def test_duplicate_labels_on_one_node_are_disambiguated(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    node = make_device(name="node-0", role_slug="control")
+    endpoint_a = make_interface(name="Ethernet3", device=node)
+    endpoint_b = make_interface(name="Ethernet5", device=node)
+    iface_a = make_interface(name="Ethernet1", connected_endpoints=[endpoint_a])
+    iface_b = make_interface(name="Ethernet2", connected_endpoints=[endpoint_b])
+    source = make_device(
+        name="switch-0",
+        role_slug="leaf",
+        device_id=10,
+        custom_fields={"device_interface_label": "data1"},
+    )
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[source, node],
+        interfaces_by_device={10: [iface_a, iface_b]},
+    )
+
+    tasks = main._generate_device_interface_labels()
+
+    by_name = {
+        t["device_interface"]["name"]: t["device_interface"]["label"] for t in tasks
+    }
+    assert by_name == {"Ethernet3": "data1a", "Ethernet5": "data1b"}

--- a/tests/unit/netbox_manager/test_loopback_generation.py
+++ b/tests/unit/netbox_manager/test_loopback_generation.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``_generate_loopback_interfaces`` (issue #253, group 1).
+
+The generator queries ``dcim.devices.all()`` and emits one ``device_interface``
+task per device for which ``should_have_loopback_interface(device)`` is truthy.
+The loopback-gate helper itself is covered in ``test_loopback_gate.py`` (Tier 1,
+#247); here only its effect inside the generator is asserted. Node / switch
+roles are pinned via ``main.settings`` so eligibility is explicit rather than
+driven by the in-module default role lists.
+"""
+
+import pytest
+
+from netbox_manager import main
+
+
+@pytest.fixture
+def roles(monkeypatch):
+    """Pin NODE_ROLES / SWITCH_ROLES so device eligibility is unambiguous."""
+    monkeypatch.setattr(main.settings, "NODE_ROLES", ["control"], raising=False)
+    monkeypatch.setattr(main.settings, "SWITCH_ROLES", ["leaf"], raising=False)
+
+
+def _wire(monkeypatch, make_netbox_api, devices):
+    """Point ``main.create_netbox_api`` at a fake API serving ``devices``."""
+    fake_api = make_netbox_api(devices=devices)
+    monkeypatch.setattr(main, "create_netbox_api", lambda: fake_api)
+    return fake_api
+
+
+def _loopback_task(name):
+    return {
+        "device_interface": {
+            "device": name,
+            "name": "Loopback0",
+            "type": "virtual",
+            "enabled": True,
+            "tags": ["managed-by-osism"],
+        }
+    }
+
+
+def test_emits_one_task_per_eligible_device_in_device_order(
+    roles, monkeypatch, make_netbox_api, make_device
+):
+    # node (eligible), sonic switch (eligible via hwsku), plain switch
+    # (ineligible: switch role without hwsku).
+    devices = [
+        make_device(name="node-0", role_slug="control"),
+        make_device(
+            name="switch-sonic",
+            role_slug="leaf",
+            custom_fields={"sonic_parameters": {"hwsku": "AS7326"}},
+        ),
+        make_device(name="switch-plain", role_slug="leaf"),
+    ]
+    _wire(monkeypatch, make_netbox_api, devices)
+
+    tasks = main._generate_loopback_interfaces()
+
+    assert tasks == [_loopback_task("node-0"), _loopback_task("switch-sonic")]
+
+
+def test_task_shape_is_exact(roles, monkeypatch, make_netbox_api, make_device):
+    _wire(
+        monkeypatch, make_netbox_api, [make_device(name="node-0", role_slug="control")]
+    )
+
+    tasks = main._generate_loopback_interfaces()
+
+    assert tasks == [
+        {
+            "device_interface": {
+                "device": "node-0",
+                "name": "Loopback0",
+                "type": "virtual",
+                "enabled": True,
+                "tags": ["managed-by-osism"],
+            }
+        }
+    ]
+
+
+def test_empty_device_list_yields_empty_list(roles, monkeypatch, make_netbox_api):
+    _wire(monkeypatch, make_netbox_api, [])
+
+    assert main._generate_loopback_interfaces() == []
+
+
+def test_only_ineligible_devices_yield_empty_list(
+    roles, monkeypatch, make_netbox_api, make_device
+):
+    devices = [
+        make_device(name="switch-plain", role_slug="leaf"),
+        make_device(name="misc", role_slug="unmapped"),
+    ]
+    _wire(monkeypatch, make_netbox_api, devices)
+
+    assert main._generate_loopback_interfaces() == []

--- a/tests/unit/netbox_manager/test_portchannel_tasks.py
+++ b/tests/unit/netbox_manager/test_portchannel_tasks.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``_generate_portchannel_tasks`` (issue #253, group 7).
+
+The generator finds switch-to-switch connections, dedups them by endpoint id,
+and -- for each switch pair with two or more connections -- emits a LAG-creation
+task per switch plus one member-assignment task per member interface. The
+PortChannel number is derived per switch from the lowest port number (the second
+number of a slashed name, otherwise the first). Roles are pinned via
+``main.settings`` so switch selection is explicit.
+
+``_connect``/``_link`` cross-links two interface bags so both switch perspectives
+see the same NetBox interface ids, exercising the dedup path realistically: each
+interface's ``device`` is its own home switch, and it appears in the other end's
+``connected_endpoints``.
+"""
+
+import pytest
+
+from netbox_manager import main
+
+
+@pytest.fixture
+def roles(monkeypatch):
+    """Pin SWITCH_ROLES / NODE_ROLES so only ``leaf`` devices are switches."""
+    monkeypatch.setattr(main.settings, "SWITCH_ROLES", ["leaf"], raising=False)
+    monkeypatch.setattr(main.settings, "NODE_ROLES", ["control"], raising=False)
+
+
+def _wire(monkeypatch, make_netbox_api, *, devices, interfaces_by_device):
+    """Point ``main.create_netbox_api`` at a fake API for the generator."""
+    fake_api = make_netbox_api(
+        devices=devices, interfaces_by_device=interfaces_by_device
+    )
+    monkeypatch.setattr(main, "create_netbox_api", lambda: fake_api)
+    return fake_api
+
+
+def _iface(make_interface, *, device, name, interface_id):
+    return make_interface(name=name, interface_id=interface_id, device=device)
+
+
+def _link(a, b, *, cabled=True):
+    """Cross-link two interface bags so each end sees the other as an endpoint."""
+    a.connected_endpoints = [b]
+    b.connected_endpoints = [a]
+    if cabled:
+        a.cable = True
+        b.cable = True
+
+
+def _lag_task(device, name):
+    return {
+        "device_interface": {
+            "device": device,
+            "name": name,
+            "type": "lag",
+            "tags": ["managed-by-osism"],
+        }
+    }
+
+
+def _member_task(device, name, lag):
+    return {
+        "device_interface": {
+            "device": device,
+            "name": name,
+            "lag": lag,
+            "tags": ["managed-by-osism"],
+        }
+    }
+
+
+def test_two_connections_emit_lags_members_dedup_and_numbering(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    sw_a = make_device(name="sw-a", role_slug="leaf", device_id=1)
+    sw_b = make_device(name="sw-b", role_slug="leaf", device_id=2)
+    a1 = _iface(make_interface, device=sw_a, name="Eth1/3/1", interface_id=101)
+    a2 = _iface(make_interface, device=sw_a, name="Eth1/4/1", interface_id=102)
+    b1 = _iface(make_interface, device=sw_b, name="Ethernet48", interface_id=201)
+    b2 = _iface(make_interface, device=sw_b, name="Ethernet49", interface_id=202)
+    _link(a1, b1)
+    _link(a2, b2)
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[sw_a, sw_b],
+        interfaces_by_device={1: [a1, a2], 2: [b1, b2]},
+    )
+
+    tasks = main._generate_portchannel_tasks()
+
+    # Eth1/3/1 -> 3, Eth1/4/1 -> 4 => min 3 => PortChannel3 on sw-a;
+    # Ethernet48/49 => min 48 => PortChannel48 on sw-b. Four sightings dedup to
+    # two connections. LAG tasks precede members, each sorted by (device, name).
+    assert tasks == [
+        _lag_task("sw-a", "PortChannel3"),
+        _lag_task("sw-b", "PortChannel48"),
+        _member_task("sw-a", "Eth1/3/1", "PortChannel3"),
+        _member_task("sw-a", "Eth1/4/1", "PortChannel3"),
+        _member_task("sw-b", "Ethernet48", "PortChannel48"),
+        _member_task("sw-b", "Ethernet49", "PortChannel48"),
+    ]
+
+
+def test_single_connection_emits_nothing(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    sw_a = make_device(name="sw-a", role_slug="leaf", device_id=1)
+    sw_b = make_device(name="sw-b", role_slug="leaf", device_id=2)
+    a1 = _iface(make_interface, device=sw_a, name="Ethernet1", interface_id=101)
+    b1 = _iface(make_interface, device=sw_b, name="Ethernet1", interface_id=201)
+    _link(a1, b1)
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[sw_a, sw_b],
+        interfaces_by_device={1: [a1], 2: [b1]},
+    )
+
+    assert main._generate_portchannel_tasks() == []
+
+
+def test_only_switch_roles_are_queried(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    sw_a = make_device(name="sw-a", role_slug="leaf", device_id=1)
+    node = make_device(name="node-0", role_slug="control", device_id=99)
+    a1 = _iface(make_interface, device=sw_a, name="Ethernet1", interface_id=101)
+    n1 = _iface(make_interface, device=node, name="Ethernet0", interface_id=901)
+    _link(a1, n1)
+    fake_api = _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[sw_a, node],
+        interfaces_by_device={1: [a1], 99: [n1]},
+    )
+
+    assert main._generate_portchannel_tasks() == []
+    queried = [call["device_id"] for call in fake_api.dcim.interfaces.filter_calls]
+    assert queried == [1]
+
+
+def test_switch_to_node_connections_are_ignored(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    # Two cables from a switch to a node: the connected role is not a switch
+    # role, so no connection is collected even though the count would meet the
+    # threshold.
+    sw_a = make_device(name="sw-a", role_slug="leaf", device_id=1)
+    node = make_device(name="node-0", role_slug="control", device_id=99)
+    a1 = _iface(make_interface, device=sw_a, name="Ethernet1", interface_id=101)
+    a2 = _iface(make_interface, device=sw_a, name="Ethernet2", interface_id=102)
+    n1 = _iface(make_interface, device=node, name="Ethernet0", interface_id=901)
+    n2 = _iface(make_interface, device=node, name="Ethernet1", interface_id=902)
+    _link(a1, n1)
+    _link(a2, n2)
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[sw_a, node],
+        interfaces_by_device={1: [a1, a2], 99: [n1, n2]},
+    )
+
+    assert main._generate_portchannel_tasks() == []
+
+
+def test_uncabled_interface_does_not_count(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    # One good link plus a second link whose interfaces are wired but not
+    # cabled: the cable gate keeps the pair at one connection, below threshold.
+    sw_a = make_device(name="sw-a", role_slug="leaf", device_id=1)
+    sw_b = make_device(name="sw-b", role_slug="leaf", device_id=2)
+    a1 = _iface(make_interface, device=sw_a, name="Ethernet1", interface_id=101)
+    b1 = _iface(make_interface, device=sw_b, name="Ethernet1", interface_id=201)
+    a2 = _iface(make_interface, device=sw_a, name="Ethernet2", interface_id=102)
+    b2 = _iface(make_interface, device=sw_b, name="Ethernet2", interface_id=202)
+    _link(a1, b1)
+    _link(a2, b2, cabled=False)
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[sw_a, sw_b],
+        interfaces_by_device={1: [a1, a2], 2: [b1, b2]},
+    )
+
+    assert main._generate_portchannel_tasks() == []
+
+
+def test_interface_without_endpoints_does_not_count(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    # One good link plus a second link whose interfaces are cabled but expose no
+    # connected endpoints: the endpoints gate keeps the pair below threshold.
+    sw_a = make_device(name="sw-a", role_slug="leaf", device_id=1)
+    sw_b = make_device(name="sw-b", role_slug="leaf", device_id=2)
+    a1 = _iface(make_interface, device=sw_a, name="Ethernet1", interface_id=101)
+    b1 = _iface(make_interface, device=sw_b, name="Ethernet1", interface_id=201)
+    a2 = make_interface(name="Ethernet2", interface_id=102, device=sw_a, cable=True)
+    b2 = make_interface(name="Ethernet2", interface_id=202, device=sw_b, cable=True)
+    _link(a1, b1)
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[sw_a, sw_b],
+        interfaces_by_device={1: [a1, a2], 2: [b1, b2]},
+    )
+
+    assert main._generate_portchannel_tasks() == []
+
+
+def test_portchannel_number_zero_when_no_digits(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    sw_a = make_device(name="sw-a", role_slug="leaf", device_id=1)
+    sw_b = make_device(name="sw-b", role_slug="leaf", device_id=2)
+    a1 = _iface(make_interface, device=sw_a, name="uplinkA", interface_id=101)
+    a2 = _iface(make_interface, device=sw_a, name="uplinkB", interface_id=102)
+    b1 = _iface(make_interface, device=sw_b, name="uplinkX", interface_id=201)
+    b2 = _iface(make_interface, device=sw_b, name="uplinkY", interface_id=202)
+    _link(a1, b1)
+    _link(a2, b2)
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[sw_a, sw_b],
+        interfaces_by_device={1: [a1, a2], 2: [b1, b2]},
+    )
+
+    tasks = main._generate_portchannel_tasks()
+
+    lag_names = {
+        (t["device_interface"]["device"], t["device_interface"]["name"])
+        for t in tasks
+        if t["device_interface"].get("type") == "lag"
+    }
+    assert lag_names == {("sw-a", "PortChannel0"), ("sw-b", "PortChannel0")}
+
+
+def test_lag_tasks_precede_members_each_sorted_by_device_and_name(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    sw_a = make_device(name="sw-a", role_slug="leaf", device_id=1)
+    sw_b = make_device(name="sw-b", role_slug="leaf", device_id=2)
+    sw_c = make_device(name="sw-c", role_slug="leaf", device_id=3)
+    a1 = _iface(make_interface, device=sw_a, name="Ethernet1", interface_id=101)
+    a2 = _iface(make_interface, device=sw_a, name="Ethernet2", interface_id=102)
+    b3 = _iface(make_interface, device=sw_b, name="Ethernet3", interface_id=203)
+    b4 = _iface(make_interface, device=sw_b, name="Ethernet4", interface_id=204)
+    c10 = _iface(make_interface, device=sw_c, name="Ethernet10", interface_id=310)
+    c11 = _iface(make_interface, device=sw_c, name="Ethernet11", interface_id=311)
+    c20 = _iface(make_interface, device=sw_c, name="Ethernet20", interface_id=320)
+    c21 = _iface(make_interface, device=sw_c, name="Ethernet21", interface_id=321)
+    _link(a1, c10)
+    _link(a2, c11)
+    _link(b3, c20)
+    _link(b4, c21)
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[sw_a, sw_b, sw_c],
+        interfaces_by_device={
+            1: [a1, a2],
+            2: [b3, b4],
+            3: [c10, c11, c20, c21],
+        },
+    )
+
+    tasks = main._generate_portchannel_tasks()
+
+    lag_tasks = [t for t in tasks if t["device_interface"].get("type") == "lag"]
+    member_tasks = [t for t in tasks if "lag" in t["device_interface"]]
+    # LAG tasks come first as a contiguous block.
+    split = len(lag_tasks)
+    assert tasks[:split] == lag_tasks
+    assert tasks[split:] == member_tasks
+
+    def key(task):
+        di = task["device_interface"]
+        return (di["device"], di["name"])
+
+    assert [key(t) for t in lag_tasks] == [
+        ("sw-a", "PortChannel1"),
+        ("sw-b", "PortChannel3"),
+        ("sw-c", "PortChannel10"),
+        ("sw-c", "PortChannel20"),
+    ]
+    assert [key(t) for t in member_tasks] == [
+        ("sw-a", "Ethernet1"),
+        ("sw-a", "Ethernet2"),
+        ("sw-b", "Ethernet3"),
+        ("sw-b", "Ethernet4"),
+        ("sw-c", "Ethernet10"),
+        ("sw-c", "Ethernet11"),
+        ("sw-c", "Ethernet20"),
+        ("sw-c", "Ethernet21"),
+    ]


### PR DESCRIPTION
Closes #253

Tier 5 of the #232 unit-test rollout. This is a **test-only** change — no production code in `netbox_manager/main.py` is touched. It adds unit tests for the loopback / cluster / interface-label / portchannel task generators and the pynetbox fixtures they need.

The generators all read NetBox through `create_netbox_api()`, so the work starts by adding a fake read-only pynetbox client to the shared `conftest.py`, then covers each generator against it.

### Change set (commit order)

1. **`8416389` Add pynetbox generator mock fixtures to conftest** — Introduces the read seams the generators query: a recording `FakeNetBoxEndpoint` (records `all()` / `filter(**kwargs)` calls, supports a `filter_lookup` and a raisable `filter_error`) and the `make_netbox_api` factory that wires up `dcim.devices`, `dcim.interfaces`, and `extras.config_contexts`. Adds `make_cluster` and `make_config_context` attribute-bag factories, and extends the existing `make_device` / `make_interface` factories (from Tier 1, #247) with the keyword-only attributes the generators read (`device_id`, `cluster`, `position`; `name`, `interface_id`, `cable`, `connected_endpoints`, `device`) — each defaulted so the pre-existing Tier 1 tests are unaffected. Fixture docstrings/header comment are updated to describe the Tier 5 seams.

2. **`91717ab` Add unit tests for Loopback0 interface generation** — `test_loopback_generation.py` covers `_generate_loopback_interfaces`: one `device_interface` task per loopback-eligible device, exact task shape, device ordering, and the empty / all-ineligible cases. NODE_ROLES / SWITCH_ROLES are pinned via `main.settings` so eligibility is explicit; the gate helper itself remains covered by Tier 1 (#247).

3. **`e983c71` Add unit tests for cluster loopback IP generation** — `test_cluster_loopbacks.py` covers the cluster loopback pipeline end to end: `_get_cluster_segment_config_context` (name match, verbatim data, falsy data, no match, lookup exception), `group_devices_by_cluster` (bucketing by `cluster.id`), `calculate_loopback_ips` (position coercion, multiplicator/offset, IPv4/IPv6 mapping and their arithmetic-error branches), and `_generate_cluster_loopback_tasks` (happy path IPv4+IPv6, skip/drop branches, per-cluster exception swallowing).

4. **`b11464a` Add unit tests for device interface label generation** — `test_interface_label_generation.py` covers `_generate_device_interface_labels`: router/firewall treated as sources while node-role devices never are, segment config-context-supplied labels, the FRR local-pref addition, skip branches, and disambiguation of duplicate labels on one node.

5. **`3784aa7` Add unit tests for PortChannel task generation** — `test_portchannel_tasks.py` covers `_generate_portchannel_tasks`: LAG + member emission with connection dedup and numbering, single-connection / switch-to-node / uncabled / no-endpoint skip cases, PortChannel numbering fallback when the name has no digits, and LAG-before-member ordering sorted by device and name.

### Notes for the reviewer

- No divergence from the issue: all four generator groups named in #253 (plus the shared group-0 fixtures) are covered.
- The `make_device` / `make_interface` extensions are additive and keyword-only, so no existing test tier changes behavior.
- Verified locally: all 50 tests in the four new files pass (`pytest`, 0.23s).

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 6b3f3ea with Claude:claude-opus-4-8_
