### PR TITLE
Unit tests: Tier 6 — autoconf generation + dispatcher

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,9 @@ os.environ.pop("NETBOX_MANAGER_SWITCH_ROLES", None)
 # client (`make_netbox_api`, backed by `FakeNetBoxEndpoint`) that the loopback /
 # cluster / interface-label / portchannel generators query -- follow, alongside
 # the `make_device` / `make_interface` keyword extensions those generators read.
+# Tier 6 (#254) extends the same two factories with the `id` / `name` /
+# `mac_address` / `mac_addresses` attributes the autoconf collectors read and
+# adds the `make_autoconf_api` fake `pynetbox.api` client for those collectors.
 # Next come the heavier `mock_ansible_runner` recorder and the loguru->`caplog`
 # bridge (Tier 4, #252). The Device Type Library seams (Tier 9, #257) -- the
 # fake `pynetbox.api` client (`make_dtl_api`), the `tmp_path` library-tree
@@ -48,19 +51,23 @@ def make_device():
 
     Returns a factory producing a :class:`types.SimpleNamespace` that exposes
     only the attributes the helpers in :mod:`netbox_manager.main` read from a
-    pynetbox device -- ``name``, ``role`` (with ``slug`` / ``name``),
+    pynetbox device -- ``id``, ``name``, ``role`` (with ``slug`` / ``name``),
     ``device_type`` (with ``model``) and ``custom_fields``. No live NetBox or
     full ``pynetbox`` mock is involved.
 
     Keyword arguments of the factory:
         name: Device name.
+        device_id: ``device.id``. The Tier 5 generators pass it as
+            ``dcim.interfaces.filter(device_id=...)`` and
+            ``_generate_autoconf_tasks`` (Tier 6, #254) uses it as the key of its
+            device dicts; defaults to ``None`` since the Tier 1 pure-logic helpers
+            never read it. Give distinct ids to devices that must coexist in one
+            ``all_devices_dict``.
         role_slug / role_name: Attributes for ``device.role``; when both are
             omitted ``device.role`` is ``None`` (an unset role).
         device_type_model: ``model`` for ``device.device_type``; when omitted
             ``device.device_type`` is ``None``.
         custom_fields: Mapping for ``device.custom_fields`` (defaults to ``{}``).
-        device_id: ``device.id`` -- the value the generators pass as
-            ``dcim.interfaces.filter(device_id=...)`` (defaults to ``None``).
         cluster: ``device.cluster`` -- a ``make_cluster`` object (or ``None``,
             the default, for a device with no cluster). Always present as an
             attribute so ``_generate_cluster_loopback_tasks``' direct
@@ -68,20 +75,21 @@ def make_device():
         position: ``device.position`` -- the rack position
             ``calculate_loopback_ips`` reads (defaults to ``None``).
 
-    The Tier 5 generator tests (#253) read ``id`` / ``cluster`` / ``position``;
-    the Tier 1 helper tests (#247) predate them and pass none of the three, so
-    every one is keyword-only with a benign default. Shared with later #232 test
-    tiers; extend it here rather than re-deriving device shapes per test module.
+    The Tier 5 generator tests (#253) read ``id`` / ``cluster`` / ``position``
+    and the Tier 6 autoconf tests (#254) read ``id``; the Tier 1 helper tests
+    (#247) predate them and pass none of the three, so every one is keyword-only
+    with a benign default. Shared with later #232 test tiers; extend it here
+    rather than re-deriving device shapes per test module.
     """
 
     def _make_device(
         *,
         name="test-device",
+        device_id=None,
         role_slug=None,
         role_name=None,
         device_type_model=None,
         custom_fields=None,
-        device_id=None,
         cluster=None,
         position=None,
     ):
@@ -101,11 +109,11 @@ def make_device():
         )
 
         return SimpleNamespace(
+            id=device_id,
             name=name,
             role=role,
             device_type=device_type,
             custom_fields={} if custom_fields is None else custom_fields,
-            id=device_id,
             cluster=cluster,
             position=position,
         )
@@ -121,15 +129,20 @@ def make_interface():
     ``type`` (with ``value`` / ``label``, all
     :func:`netbox_manager.main.is_virtual_interface` reads) plus the attributes
     the Tier 5 generators (#253) read off a ``dcim.interfaces.filter(...)``
-    record. When neither ``type_value`` nor ``type_label`` is given, ``type`` is
-    ``None``.
+    record and the ``id`` / ``name`` / ``mac_address`` / ``mac_addresses``
+    attributes the Tier 6 (#254) autoconf collectors read. When neither
+    ``type_value`` nor ``type_label`` is given, ``type`` is ``None``.
 
     Keyword arguments of the factory:
-        type_value / type_label: Attributes for ``interface.type``.
+        type_value / type_label: Attributes for ``interface.type``; when both
+            are omitted ``interface.type`` is ``None``.
         name: ``interface.name`` -- the port name emitted into label / member
-            tasks and read off a connected endpoint (defaults to ``None``).
+            tasks and read off a connected endpoint, and the value
+            ``collect_ip_assignments_by_interface`` filters on (defaults to
+            ``None``).
         interface_id: ``interface.id`` -- the identity the PortChannel dedup
-            matches connections on (defaults to ``None``).
+            matches connections on and the ``assigned_object_id`` the IP lookup
+            keys on (defaults to ``None``).
         cable: ``interface.cable`` -- a truthy value marks the port cabled;
             ``None`` (the default) exercises the not-cabled skip branch.
         connected_endpoints: ``interface.connected_endpoints`` -- a list of
@@ -140,6 +153,11 @@ def make_interface():
             interface used as a connected endpoint so the generator can read the
             far-side device back off it (mirrors a real NetBox record); ``None``
             (the default) exercises the endpoint-without-device skip branch.
+        mac_address: The direct MAC ``collect_interface_assignments`` prefers.
+        mac_addresses: The fallback list of records with a ``mac_address``
+            attribute (build entries inline as
+            ``SimpleNamespace(mac_address=...)``); defaults to ``[]`` so the
+            falsy check in the collector works without a guard.
 
     Shared with later #232 test tiers.
     """
@@ -153,6 +171,8 @@ def make_interface():
         cable=None,
         connected_endpoints=None,
         device=None,
+        mac_address=None,
+        mac_addresses=None,
     ):
         if type_value is None and type_label is None:
             interface_type = None
@@ -169,6 +189,8 @@ def make_interface():
             cable=cable,
             connected_endpoints=connected_endpoints,
             device=device,
+            mac_address=mac_address,
+            mac_addresses=[] if mac_addresses is None else mac_addresses,
         )
 
     return _make_interface
@@ -307,6 +329,66 @@ def make_netbox_api():
                     ),
                     filter_error=config_contexts_error,
                 ),
+            ),
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_autoconf_api():
+    """Return a factory building a fake ``pynetbox.api`` client for autoconf.
+
+    ``make_autoconf_api(devices=..., interfaces_by_device=..., ips_by_interface=...)``
+    returns a :class:`types.SimpleNamespace` exposing exactly the three read-only
+    endpoints the Tier 6 (#254) autoconf collectors touch:
+
+        dcim.devices.all() -> ``list(devices)`` (what ``_generate_autoconf_tasks``
+            loads before splitting switches from non-switches).
+        dcim.interfaces.filter(device_id, name=None) ->
+            ``interfaces_by_device[device_id]``, additionally narrowed to the
+            interfaces whose ``name`` matches when ``name`` is passed (the
+            ``eth0`` / ``Loopback0`` lookups in
+            ``collect_ip_assignments_by_interface``).
+        ipam.ip_addresses.filter(assigned_object_id) ->
+            ``ips_by_interface[assigned_object_id]`` (IP records are plain
+            ``SimpleNamespace(address=...)`` bags).
+
+    Arguments (all optional, defaulting to empty):
+        devices: iterable of ``make_device`` bags returned by ``devices.all()``.
+        interfaces_by_device: ``{device_id: [make_interface bag, ...]}`` keyed by
+            the ``device_id`` the collectors pass to ``interfaces.filter``.
+        ips_by_interface: ``{interface_id: [SimpleNamespace(address=...), ...]}``
+            keyed by ``interface.id``.
+
+    Inject it with ``monkeypatch.setattr(main, "create_netbox_api", lambda: api)``
+    for ``_generate_autoconf_tasks``, or pass it straight to the collectors that
+    take a ``netbox_api`` argument. Shared with the mock-heavy later tiers
+    (#255 validation adds ``ipam.prefixes`` / ``dcim.interfaces.get`` on top) --
+    extend this fixture with the extra endpoints rather than forking it.
+    """
+
+    def _make(*, devices=None, interfaces_by_device=None, ips_by_interface=None):
+        devices = list(devices or [])
+        interfaces_by_device = interfaces_by_device or {}
+        ips_by_interface = ips_by_interface or {}
+
+        def _filter_interfaces(*, device_id, name=None):
+            interfaces = list(interfaces_by_device.get(device_id, []))
+            if name is not None:
+                interfaces = [iface for iface in interfaces if iface.name == name]
+            return interfaces
+
+        def _filter_ips(*, assigned_object_id):
+            return list(ips_by_interface.get(assigned_object_id, []))
+
+        return SimpleNamespace(
+            dcim=SimpleNamespace(
+                devices=SimpleNamespace(all=lambda: list(devices)),
+                interfaces=SimpleNamespace(filter=_filter_interfaces),
+            ),
+            ipam=SimpleNamespace(
+                ip_addresses=SimpleNamespace(filter=_filter_ips),
             ),
         )
 

--- a/tests/unit/netbox_manager/test_autoconf_collect.py
+++ b/tests/unit/netbox_manager/test_autoconf_collect.py
@@ -1,0 +1,412 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the autoconf collectors in ``netbox_manager.main`` (#254).
+
+Tier 6 groups 1-3 of the coverage effort tracked in #232. These cover the
+functions that walk a (mocked) NetBox API to collect per-interface MAC
+assignments and per-device IP assignments, and the ``_generate_autoconf_tasks``
+orchestrator that assembles them into the ``tasks_by_type`` payload:
+
+* ``collect_interface_assignments`` -- MAC resolution (direct vs. fallback),
+  the virtual-interface skip, the emitted task shape and name-sorted ordering.
+* ``collect_ip_assignments_by_interface`` -- OOB vs. primary IPv4/IPv6 routing,
+  per-device grouping and merging, empty/no-match handling, and ordering.
+* ``_generate_autoconf_tasks`` -- the switch/non-switch split, the interface
+  and device buckets, the OOB+primary per-device merge, and the returned bucket
+  keys.
+
+The collectors read from a live ``pynetbox.api`` client, so the fake
+``make_autoconf_api`` client from ``conftest`` (extending the Tier 1 #247
+``make_device`` / ``make_interface`` factories) stands in for NetBox;
+``_generate_autoconf_tasks`` additionally calls ``create_netbox_api`` and is
+tested by patching ``main.create_netbox_api``.
+
+Out of scope here: the pure helpers ``is_virtual_interface`` /
+``get_device_role_slug`` / ``get_switch_roles`` (Tier 1, #247), the generators
+feeding the dispatcher (Tier 5, #253), the ``_write_autoconf_files`` internals
+(Tier 3, #259) and the ``_run_autoconf_for_devices`` dispatcher and CLI wiring
+(covered in ``test_autoconf_dispatch.py`` / Tier 10). No live NetBox or
+``ansible_runner`` is involved.
+"""
+
+import logging
+from types import SimpleNamespace
+
+from netbox_manager import main
+
+
+def _ip(address):
+    """Build an IP-address record bag exposing only ``.address``."""
+    return SimpleNamespace(address=address)
+
+
+class TestCollectInterfaceAssignments:
+    """Group 1 -- ``collect_interface_assignments`` MAC collection."""
+
+    def test_virtual_interface_is_skipped(
+        self, make_autoconf_api, make_device, make_interface
+    ):
+        # Both the value- and label-detected virtual interfaces are skipped even
+        # though they carry a MAC that would otherwise be emitted.
+        devices = {1: make_device(name="node-0")}
+        interfaces = [
+            make_interface(
+                name="Vlan1", type_value="virtual", mac_address="aa:bb:cc:00:00:01"
+            ),
+            make_interface(
+                name="Vlan2", type_label="Virtual", mac_address="aa:bb:cc:00:00:02"
+            ),
+        ]
+        api = make_autoconf_api(interfaces_by_device={1: interfaces})
+
+        assert main.collect_interface_assignments(api, devices) == []
+
+    def test_direct_mac_address_is_used(
+        self, make_autoconf_api, make_device, make_interface, make_dtl_record
+    ):
+        # A truthy `mac_address` wins and is coerced with `str(...)`; a non-str
+        # record object pins that coercion.
+        devices = {1: make_device(name="node-0")}
+        mac_record = make_dtl_record("18:C0:86:D4:E2:F7")
+        interface = make_interface(name="Ethernet0", mac_address=mac_record)
+        api = make_autoconf_api(interfaces_by_device={1: [interface]})
+
+        tasks = main.collect_interface_assignments(api, devices)
+
+        assert (
+            tasks[0]["device_interface"]["primary_mac_address"] == "18:C0:86:D4:E2:F7"
+        )
+        assert isinstance(tasks[0]["device_interface"]["primary_mac_address"], str)
+
+    def test_falls_back_to_first_mac_addresses_entry(
+        self, make_autoconf_api, make_device, make_interface
+    ):
+        # With no direct MAC, the first `mac_addresses` entry is used.
+        devices = {1: make_device(name="node-0")}
+        interface = make_interface(
+            name="Ethernet0",
+            mac_address=None,
+            mac_addresses=[
+                SimpleNamespace(mac_address="aa:bb:cc:00:00:01"),
+                SimpleNamespace(mac_address="aa:bb:cc:00:00:02"),
+            ],
+        )
+        api = make_autoconf_api(interfaces_by_device={1: [interface]})
+
+        tasks = main.collect_interface_assignments(api, devices)
+
+        assert (
+            tasks[0]["device_interface"]["primary_mac_address"] == "aa:bb:cc:00:00:01"
+        )
+
+    def test_interface_without_mac_emits_no_task(
+        self, make_autoconf_api, make_device, make_interface
+    ):
+        # Neither source yields a MAC -> nothing is appended.
+        devices = {1: make_device(name="node-0")}
+        interface = make_interface(name="Ethernet0", mac_address=None, mac_addresses=[])
+        api = make_autoconf_api(interfaces_by_device={1: [interface]})
+
+        assert main.collect_interface_assignments(api, devices) == []
+
+    def test_emitted_task_shape(self, make_autoconf_api, make_device, make_interface):
+        devices = {1: make_device(name="node-0")}
+        interface = make_interface(name="Ethernet0", mac_address="aa:bb:cc:00:00:01")
+        api = make_autoconf_api(interfaces_by_device={1: [interface]})
+
+        tasks = main.collect_interface_assignments(api, devices)
+
+        assert tasks == [
+            {
+                "device_interface": {
+                    "device": "node-0",
+                    "name": "Ethernet0",
+                    "primary_mac_address": "aa:bb:cc:00:00:01",
+                }
+            }
+        ]
+
+    def test_devices_iterated_in_name_sorted_order(
+        self, make_autoconf_api, make_device, make_interface
+    ):
+        # Devices are iterated in name-sorted order regardless of dict key order.
+        devices = {
+            1: make_device(name="b-node"),
+            2: make_device(name="a-node"),
+        }
+        interfaces_by_device = {
+            1: [make_interface(name="Ethernet0", mac_address="aa:bb:cc:00:00:0b")],
+            2: [make_interface(name="Ethernet0", mac_address="aa:bb:cc:00:00:0a")],
+        }
+        api = make_autoconf_api(interfaces_by_device=interfaces_by_device)
+
+        tasks = main.collect_interface_assignments(api, devices)
+
+        assert [task["device_interface"]["device"] for task in tasks] == [
+            "a-node",
+            "b-node",
+        ]
+
+
+class TestCollectIpAssignmentsByInterface:
+    """Group 2 -- ``collect_ip_assignments_by_interface`` IP collection."""
+
+    def test_seeds_entry_with_device_name(
+        self, make_autoconf_api, make_device, make_interface
+    ):
+        devices = {1: make_device(name="node-0")}
+        interface = make_interface(name="eth0", interface_id=10)
+        api = make_autoconf_api(
+            interfaces_by_device={1: [interface]},
+            ips_by_interface={10: [_ip("172.16.0.10/20")]},
+        )
+
+        result = main.collect_ip_assignments_by_interface(api, devices, "eth0", "OOB")
+
+        assert result["node-0"]["name"] == "node-0"
+
+    def test_oob_type_writes_oob_ip(
+        self, make_autoconf_api, make_device, make_interface
+    ):
+        devices = {1: make_device(name="node-0")}
+        interface = make_interface(name="eth0", interface_id=10)
+        api = make_autoconf_api(
+            interfaces_by_device={1: [interface]},
+            ips_by_interface={10: [_ip("172.16.0.10/20")]},
+        )
+
+        result = main.collect_ip_assignments_by_interface(api, devices, "eth0", "OOB")
+
+        assert result["node-0"]["oob_ip"] == "172.16.0.10/20"
+        assert "primary_ip4" not in result["node-0"]
+
+    def test_primary_ipv4_written_for_dotted_address(
+        self, make_autoconf_api, make_device, make_interface
+    ):
+        devices = {1: make_device(name="node-0")}
+        interface = make_interface(name="Loopback0", interface_id=10)
+        api = make_autoconf_api(
+            interfaces_by_device={1: [interface]},
+            ips_by_interface={10: [_ip("192.168.16.10/32")]},
+        )
+
+        result = main.collect_ip_assignments_by_interface(
+            api, devices, "Loopback0", "Primary"
+        )
+
+        assert result["node-0"]["primary_ip4"] == "192.168.16.10/32"
+        assert "primary_ip6" not in result["node-0"]
+
+    def test_primary_ipv6_written_for_colon_address(
+        self, make_autoconf_api, make_device, make_interface
+    ):
+        devices = {1: make_device(name="node-0")}
+        interface = make_interface(name="Loopback0", interface_id=10)
+        api = make_autoconf_api(
+            interfaces_by_device={1: [interface]},
+            ips_by_interface={10: [_ip("fda6:f659:8c2b::192:168:16:10/128")]},
+        )
+
+        result = main.collect_ip_assignments_by_interface(
+            api, devices, "Loopback0", "Primary"
+        )
+
+        assert result["node-0"]["primary_ip6"] == "fda6:f659:8c2b::192:168:16:10/128"
+        assert "primary_ip4" not in result["node-0"]
+
+    def test_multiple_ips_accumulate_per_device(
+        self, make_autoconf_api, make_device, make_interface
+    ):
+        # An IPv4 and an IPv6 on the same interface merge into one assignment.
+        devices = {1: make_device(name="node-0")}
+        interface = make_interface(name="Loopback0", interface_id=10)
+        api = make_autoconf_api(
+            interfaces_by_device={1: [interface]},
+            ips_by_interface={10: [_ip("192.168.16.10/32"), _ip("fda6::10/128")]},
+        )
+
+        result = main.collect_ip_assignments_by_interface(
+            api, devices, "Loopback0", "Primary"
+        )
+
+        assert result["node-0"] == {
+            "name": "node-0",
+            "primary_ip4": "192.168.16.10/32",
+            "primary_ip6": "fda6::10/128",
+        }
+
+    def test_no_matching_interface_or_empty_input(
+        self, make_autoconf_api, make_device, make_interface
+    ):
+        # A device whose named interface is absent contributes no key.
+        devices = {1: make_device(name="node-0")}
+        interface = make_interface(name="Ethernet0", interface_id=10)
+        api = make_autoconf_api(
+            interfaces_by_device={1: [interface]},
+            ips_by_interface={10: [_ip("172.16.0.10/20")]},
+        )
+        assert (
+            main.collect_ip_assignments_by_interface(api, devices, "eth0", "OOB") == {}
+        )
+
+        # No devices at all -> empty result.
+        empty_api = make_autoconf_api()
+        assert (
+            main.collect_ip_assignments_by_interface(empty_api, {}, "eth0", "OOB") == {}
+        )
+
+    def test_result_keys_in_name_sorted_order(
+        self, make_autoconf_api, make_device, make_interface
+    ):
+        devices = {
+            1: make_device(name="node-b"),
+            2: make_device(name="node-a"),
+        }
+        interfaces_by_device = {
+            1: [make_interface(name="eth0", interface_id=11)],
+            2: [make_interface(name="eth0", interface_id=12)],
+        }
+        ips_by_interface = {
+            11: [_ip("172.16.0.11/20")],
+            12: [_ip("172.16.0.12/20")],
+        }
+        api = make_autoconf_api(
+            interfaces_by_device=interfaces_by_device,
+            ips_by_interface=ips_by_interface,
+        )
+
+        result = main.collect_ip_assignments_by_interface(api, devices, "eth0", "OOB")
+
+        assert list(result.keys()) == ["node-a", "node-b"]
+
+
+class TestGenerateAutoconfTasks:
+    """Group 3 -- ``_generate_autoconf_tasks`` orchestration."""
+
+    def test_switch_split_is_logged(
+        self, monkeypatch, caplog, make_autoconf_api, make_device
+    ):
+        monkeypatch.setattr(main.settings, "SWITCH_ROLES", ["leaf"], raising=False)
+        devices = [
+            make_device(name="switch-0", device_id=1, role_slug="leaf"),
+            make_device(name="node-0", device_id=2, role_slug="control"),
+        ]
+        api = make_autoconf_api(devices=devices)
+        monkeypatch.setattr(main, "create_netbox_api", lambda: api)
+
+        with caplog.at_level(logging.INFO):
+            main._generate_autoconf_tasks()
+
+        assert "2 total devices (1 non-switch, 1 switches)" in caplog.text
+
+    def test_interface_bucket_includes_switch_macs(
+        self, monkeypatch, make_autoconf_api, make_device, make_interface
+    ):
+        # `collect_interface_assignments` runs over ALL devices, so a switch's
+        # MAC lands in the device_interface bucket too.
+        monkeypatch.setattr(main.settings, "SWITCH_ROLES", ["leaf"], raising=False)
+        devices = [
+            make_device(name="switch-0", device_id=1, role_slug="leaf"),
+            make_device(name="node-0", device_id=2, role_slug="control"),
+        ]
+        interfaces_by_device = {
+            1: [make_interface(name="Ethernet0", mac_address="aa:bb:cc:00:00:01")],
+            2: [make_interface(name="Ethernet0", mac_address="aa:bb:cc:00:00:02")],
+        }
+        api = make_autoconf_api(
+            devices=devices, interfaces_by_device=interfaces_by_device
+        )
+        monkeypatch.setattr(main, "create_netbox_api", lambda: api)
+
+        result = main._generate_autoconf_tasks()
+
+        names = {
+            task["device_interface"]["device"] for task in result["device_interface"]
+        }
+        assert names == {"switch-0", "node-0"}
+
+    def test_oob_and_primary_merge_by_device_name(
+        self, monkeypatch, make_autoconf_api, make_device, make_interface
+    ):
+        # eth0 (OOB) and Loopback0 (IPv4 + IPv6) merge into one device task.
+        devices = [make_device(name="node-0", device_id=1, role_slug="control")]
+        interfaces_by_device = {
+            1: [
+                make_interface(name="eth0", interface_id=10),
+                make_interface(name="Loopback0", interface_id=11),
+            ]
+        }
+        ips_by_interface = {
+            10: [_ip("172.16.0.10/20")],
+            11: [_ip("192.168.16.10/32"), _ip("fda6::10/128")],
+        }
+        api = make_autoconf_api(
+            devices=devices,
+            interfaces_by_device=interfaces_by_device,
+            ips_by_interface=ips_by_interface,
+        )
+        monkeypatch.setattr(main, "create_netbox_api", lambda: api)
+
+        result = main._generate_autoconf_tasks()
+
+        assert result["device"] == [
+            {
+                "device": {
+                    "name": "node-0",
+                    "oob_ip": "172.16.0.10/20",
+                    "primary_ip4": "192.168.16.10/32",
+                    "primary_ip6": "fda6::10/128",
+                }
+            }
+        ]
+        # The MAC-less interfaces leave the interface bucket empty.
+        assert result["device_interface"] == []
+
+    def test_device_bucket_sorted_by_device_name(
+        self, monkeypatch, make_autoconf_api, make_device, make_interface
+    ):
+        # Devices are returned in reverse-name order but the device bucket is
+        # emitted in sorted-name order.
+        devices = [
+            make_device(name="node-b", device_id=1, role_slug="control"),
+            make_device(name="node-a", device_id=2, role_slug="control"),
+        ]
+        interfaces_by_device = {
+            1: [make_interface(name="eth0", interface_id=11)],
+            2: [make_interface(name="eth0", interface_id=12)],
+        }
+        ips_by_interface = {
+            11: [_ip("172.16.0.11/20")],
+            12: [_ip("172.16.0.12/20")],
+        }
+        api = make_autoconf_api(
+            devices=devices,
+            interfaces_by_device=interfaces_by_device,
+            ips_by_interface=ips_by_interface,
+        )
+        monkeypatch.setattr(main, "create_netbox_api", lambda: api)
+
+        result = main._generate_autoconf_tasks()
+
+        assert [task["device"]["name"] for task in result["device"]] == [
+            "node-a",
+            "node-b",
+        ]
+
+    def test_returned_bucket_keys_and_empty_ip_address(
+        self, monkeypatch, make_autoconf_api, make_device, make_interface
+    ):
+        devices = [make_device(name="node-0", device_id=1, role_slug="control")]
+        interfaces_by_device = {
+            1: [make_interface(name="Ethernet0", mac_address="aa:bb:cc:00:00:01")]
+        }
+        api = make_autoconf_api(
+            devices=devices, interfaces_by_device=interfaces_by_device
+        )
+        monkeypatch.setattr(main, "create_netbox_api", lambda: api)
+
+        result = main._generate_autoconf_tasks()
+
+        assert set(result.keys()) == {"device", "device_interface", "ip_address"}
+        # No `ip_address` tasks are ever produced by this function.
+        assert result["ip_address"] == []

--- a/tests/unit/netbox_manager/test_autoconf_dispatch.py
+++ b/tests/unit/netbox_manager/test_autoconf_dispatch.py
@@ -1,0 +1,495 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``_run_autoconf_for_devices`` in ``netbox_manager.main`` (#254).
+
+Tier 6 group 4 of the coverage effort tracked in #232. ``_run_autoconf_for_devices``
+is the dispatcher: it calls the five task generators, merges the interface-label
+tasks into the autoconf ``device_interface`` tasks, optionally applies a
+device-name filter across every task source, and then either previews the
+result (dry-run) or routes the assembled ``all_tasks_by_type`` payload into
+``_write_autoconf_files``.
+
+The five generators (``_generate_loopback_interfaces``,
+``_generate_cluster_loopback_tasks``, ``_generate_portchannel_tasks``,
+``_generate_device_interface_labels``, ``_generate_autoconf_tasks``) are Tier 5
+(#253) / group 3 above -- here they are patched to fixed task lists/dicts so the
+merge, filter and routing logic is exercised in isolation. ``_write_autoconf_files``
+is Tier 3 (#259) -- most tests spy on it to assert the routing decision and the
+handed-over payload, and one integration test lets the real writer run against
+``tmp_path``. The pure filter/split helpers are Tier 1 (#247). No live NetBox or
+``ansible_runner`` is involved.
+"""
+
+import logging
+from copy import deepcopy
+
+from netbox_manager import main
+
+
+def _patch_generators(
+    monkeypatch,
+    *,
+    loopback=None,
+    cluster=None,
+    portchannel=None,
+    labels=None,
+    autoconf=None,
+):
+    """Patch the five autoconf generators to return fixed copies.
+
+    Each generator is replaced with a lambda returning a fresh ``deepcopy`` of
+    the supplied value so the dispatcher can mutate/merge freely without the
+    fixture data leaking between calls or into the caller's assertions.
+    """
+    loopback = loopback or []
+    cluster = cluster or {}
+    portchannel = portchannel or []
+    labels = labels or []
+    autoconf = autoconf or {"device": [], "device_interface": [], "ip_address": []}
+
+    monkeypatch.setattr(
+        main, "_generate_loopback_interfaces", lambda: deepcopy(loopback)
+    )
+    monkeypatch.setattr(
+        main, "_generate_cluster_loopback_tasks", lambda: deepcopy(cluster)
+    )
+    monkeypatch.setattr(
+        main, "_generate_portchannel_tasks", lambda: deepcopy(portchannel)
+    )
+    monkeypatch.setattr(
+        main, "_generate_device_interface_labels", lambda: deepcopy(labels)
+    )
+    monkeypatch.setattr(main, "_generate_autoconf_tasks", lambda: deepcopy(autoconf))
+
+
+class _WriteSpy:
+    """Records calls to ``_write_autoconf_files`` and returns a sentinel count."""
+
+    def __init__(self, monkeypatch, return_value=1):
+        self.calls = []
+        self.return_value = return_value
+        monkeypatch.setattr(main, "_write_autoconf_files", self._record)
+
+    def _record(self, tasks_by_type, file_prefix, resources_dir=None):
+        self.calls.append((tasks_by_type, file_prefix, resources_dir))
+        return self.return_value
+
+
+class TestRunAutoconfForDevices:
+    """Group 4 -- ``_run_autoconf_for_devices`` merge, filter and routing."""
+
+    def test_label_merge_passthrough_and_leftovers(self, monkeypatch):
+        # node-0:Ethernet3 exists in both autoconf and labels (label side wins),
+        # node-1:Ethernet0 is autoconf-only (passthrough), node-9:Ethernet7 is
+        # label-only (appended last).
+        autoconf = {
+            "device": [],
+            "device_interface": [
+                {
+                    "device_interface": {
+                        "device": "node-0",
+                        "name": "Ethernet3",
+                        "primary_mac_address": "aa:bb:cc:00:00:03",
+                        "enabled": False,
+                    }
+                },
+                {
+                    "device_interface": {
+                        "device": "node-1",
+                        "name": "Ethernet0",
+                        "primary_mac_address": "aa:bb:cc:00:00:10",
+                    }
+                },
+            ],
+            "ip_address": [],
+        }
+        labels = [
+            {
+                "device_interface": {
+                    "device": "node-0",
+                    "name": "Ethernet3",
+                    "label": "uplink",
+                    "enabled": True,
+                }
+            },
+            {
+                "device_interface": {
+                    "device": "node-9",
+                    "name": "Ethernet7",
+                    "label": "spare",
+                }
+            },
+        ]
+        _patch_generators(monkeypatch, labels=labels, autoconf=autoconf)
+        spy = _WriteSpy(monkeypatch)
+
+        main._run_autoconf_for_devices(None, "out")
+
+        payload = spy.calls[0][0]
+        assert payload["device_interface"] == [
+            {
+                "device_interface": {
+                    "device": "node-0",
+                    "name": "Ethernet3",
+                    "primary_mac_address": "aa:bb:cc:00:00:03",
+                    "enabled": True,
+                    "label": "uplink",
+                }
+            },
+            {
+                "device_interface": {
+                    "device": "node-1",
+                    "name": "Ethernet0",
+                    "primary_mac_address": "aa:bb:cc:00:00:10",
+                }
+            },
+            {
+                "device_interface": {
+                    "device": "node-9",
+                    "name": "Ethernet7",
+                    "label": "spare",
+                }
+            },
+        ]
+
+    def test_device_and_ip_address_buckets_pass_through(self, monkeypatch):
+        autoconf = {
+            "device": [
+                {"device": {"name": "node-0", "primary_ip4": "192.168.16.10/32"}}
+            ],
+            "device_interface": [],
+            "ip_address": [{"ip_address": {"address": "10.0.0.1/32"}}],
+        }
+        _patch_generators(monkeypatch, autoconf=autoconf)
+        spy = _WriteSpy(monkeypatch)
+
+        main._run_autoconf_for_devices(None, "out")
+
+        payload = spy.calls[0][0]
+        assert payload["device"] == autoconf["device"]
+        assert payload["ip_address"] == autoconf["ip_address"]
+
+    def test_device_filter_intersects_every_source(self, monkeypatch):
+        loopback = [
+            {
+                "device_interface": {
+                    "device": "node-0",
+                    "name": "Loopback0",
+                    "src": "loopback",
+                }
+            },
+            {
+                "device_interface": {
+                    "device": "node-1",
+                    "name": "Loopback0",
+                    "src": "loopback",
+                }
+            },
+        ]
+        cluster = {
+            "ip_address": [
+                {"ip_address": {"device": "node-0", "src": "cluster"}},
+                {"ip_address": {"device": "node-1", "src": "cluster"}},
+            ]
+        }
+        portchannel = [
+            {
+                "device_interface": {
+                    "device": "node-0",
+                    "name": "PortChannel1",
+                    "src": "pc",
+                }
+            },
+            {
+                "device_interface": {
+                    "device": "node-1",
+                    "name": "PortChannel1",
+                    "src": "pc",
+                }
+            },
+        ]
+        autoconf = {
+            "device": [
+                {"device": {"name": "node-0", "src": "autoconf-dev"}},
+                {"device": {"name": "node-1", "src": "autoconf-dev"}},
+            ],
+            "device_interface": [
+                {
+                    "device_interface": {
+                        "device": "node-0",
+                        "name": "Ethernet0",
+                        "src": "autoconf-di",
+                    }
+                },
+                {
+                    "device_interface": {
+                        "device": "node-1",
+                        "name": "Ethernet0",
+                        "src": "autoconf-di",
+                    }
+                },
+            ],
+            "ip_address": [],
+        }
+        _patch_generators(
+            monkeypatch,
+            loopback=loopback,
+            cluster=cluster,
+            portchannel=portchannel,
+            autoconf=autoconf,
+        )
+        spy = _WriteSpy(monkeypatch)
+
+        main._run_autoconf_for_devices({"node-0"}, "out")
+
+        payload = spy.calls[0][0]
+        # Every source contributes exactly its node-0 half; no node-1 survives.
+        srcs = []
+        for tasks in payload.values():
+            for task in tasks:
+                inner = next(iter(task.values()))
+                assert inner.get("device", inner.get("name")) == "node-0"
+                srcs.append(inner["src"])
+        assert sorted(srcs) == [
+            "autoconf-dev",
+            "autoconf-di",
+            "cluster",
+            "loopback",
+            "pc",
+        ]
+
+    def test_device_filter_none_keeps_everything(self, monkeypatch):
+        loopback = [
+            {
+                "device_interface": {
+                    "device": "node-0",
+                    "name": "Loopback0",
+                    "src": "loopback",
+                }
+            },
+            {
+                "device_interface": {
+                    "device": "node-1",
+                    "name": "Loopback0",
+                    "src": "loopback",
+                }
+            },
+        ]
+        cluster = {
+            "ip_address": [
+                {"ip_address": {"device": "node-0", "src": "cluster"}},
+                {"ip_address": {"device": "node-1", "src": "cluster"}},
+            ]
+        }
+        portchannel = [
+            {
+                "device_interface": {
+                    "device": "node-0",
+                    "name": "PortChannel1",
+                    "src": "pc",
+                }
+            },
+            {
+                "device_interface": {
+                    "device": "node-1",
+                    "name": "PortChannel1",
+                    "src": "pc",
+                }
+            },
+        ]
+        autoconf = {
+            "device": [
+                {"device": {"name": "node-0", "src": "autoconf-dev"}},
+                {"device": {"name": "node-1", "src": "autoconf-dev"}},
+            ],
+            "device_interface": [
+                {
+                    "device_interface": {
+                        "device": "node-0",
+                        "name": "Ethernet0",
+                        "src": "autoconf-di",
+                    }
+                },
+                {
+                    "device_interface": {
+                        "device": "node-1",
+                        "name": "Ethernet0",
+                        "src": "autoconf-di",
+                    }
+                },
+            ],
+            "ip_address": [],
+        }
+        _patch_generators(
+            monkeypatch,
+            loopback=loopback,
+            cluster=cluster,
+            portchannel=portchannel,
+            autoconf=autoconf,
+        )
+        spy = _WriteSpy(monkeypatch)
+
+        main._run_autoconf_for_devices(None, "out")
+
+        payload = spy.calls[0][0]
+        pairs = set()
+        for tasks in payload.values():
+            for task in tasks:
+                inner = next(iter(task.values()))
+                pairs.add((inner["src"], inner.get("device", inner.get("name"))))
+        # Both devices survive for every source when no filter is applied.
+        assert pairs == {
+            ("loopback", "node-0"),
+            ("loopback", "node-1"),
+            ("cluster", "node-0"),
+            ("cluster", "node-1"),
+            ("pc", "node-0"),
+            ("pc", "node-1"),
+            ("autoconf-dev", "node-0"),
+            ("autoconf-dev", "node-1"),
+            ("autoconf-di", "node-0"),
+            ("autoconf-di", "node-1"),
+        }
+
+    def test_dry_run_previews_and_writes_nothing(self, monkeypatch, tmp_path, caplog):
+        # The real writer is left in place; the dry-run path must return before
+        # reaching it, so no file appears and the writer is never invoked.
+        loopback = [{"device_interface": {"device": "node-0", "name": "Loopback0"}}]
+        cluster = {"ip_address": [{"ip_address": {"device": "node-0"}}]}
+        autoconf = {
+            "device": [],
+            "device_interface": [
+                {"device_interface": {"device": "node-0", "name": "Ethernet0"}}
+            ],
+            "ip_address": [],
+        }
+        _patch_generators(
+            monkeypatch, loopback=loopback, cluster=cluster, autoconf=autoconf
+        )
+        out = tmp_path / "out"
+
+        with caplog.at_level(logging.INFO):
+            result = main._run_autoconf_for_devices(None, str(out), dryrun=True)
+
+        assert result == 0
+        assert not out.exists()
+        assert "would generate the following loopback interface tasks:" in caplog.text
+        assert (
+            "would generate the following cluster-based loopback IP tasks:"
+            in caplog.text
+        )
+        assert "would generate the following other autoconf tasks:" in caplog.text
+        # PortChannel source was empty, so its preview header is absent.
+        assert "PortChannel LAG interface tasks:" not in caplog.text
+
+    def test_file_write_path_routes_assembled_payload(self, monkeypatch, tmp_path):
+        loopback = [{"device_interface": {"device": "node-0", "name": "Loopback0"}}]
+        cluster = {
+            "ip_address": [
+                {"ip_address": {"device": "node-0", "address": "10.0.0.1/32"}}
+            ]
+        }
+        portchannel = [
+            {
+                "device_interface": {
+                    "device": "node-0",
+                    "name": "PortChannel1",
+                    "type": "lag",
+                }
+            }
+        ]
+        autoconf = {
+            "device": [{"device": {"name": "node-0"}}],
+            "device_interface": [
+                {"device_interface": {"device": "node-0", "name": "Ethernet0"}}
+            ],
+            "ip_address": [],
+        }
+        _patch_generators(
+            monkeypatch,
+            loopback=loopback,
+            cluster=cluster,
+            portchannel=portchannel,
+            autoconf=autoconf,
+        )
+        spy = _WriteSpy(monkeypatch, return_value=7)
+
+        result = main._run_autoconf_for_devices(
+            None, str(tmp_path), prefix="299-autoconf"
+        )
+
+        assert result == 7
+        expected_payload = {
+            # loopback -> then autoconf -> then portchannel appended last.
+            "device_interface": [
+                {"device_interface": {"device": "node-0", "name": "Loopback0"}},
+                {"device_interface": {"device": "node-0", "name": "Ethernet0"}},
+                {
+                    "device_interface": {
+                        "device": "node-0",
+                        "name": "PortChannel1",
+                        "type": "lag",
+                    }
+                },
+            ],
+            "ip_address": [
+                {"ip_address": {"device": "node-0", "address": "10.0.0.1/32"}}
+            ],
+            "device": [{"device": {"name": "node-0"}}],
+        }
+        assert spy.calls == [(expected_payload, "299-autoconf", str(tmp_path))]
+
+    def test_file_write_path_writes_real_files(self, monkeypatch, tmp_path):
+        # Integration with the Tier 3-covered writer: the count equals the number
+        # of non-empty buckets and the expected files land on disk.
+        loopback = [{"device_interface": {"device": "node-0", "name": "Loopback0"}}]
+        autoconf = {
+            "device": [{"device": {"name": "node-0"}}],
+            "device_interface": [],
+            "ip_address": [],
+        }
+        _patch_generators(monkeypatch, loopback=loopback, autoconf=autoconf)
+
+        result = main._run_autoconf_for_devices(
+            None, str(tmp_path), prefix="299-autoconf"
+        )
+
+        assert result == 2
+        assert (tmp_path / "299-autoconf-device-interface.yml").is_file()
+        assert (tmp_path / "299-autoconf-device.yml").is_file()
+
+    def test_returns_zero_when_filter_removes_everything(self, monkeypatch):
+        loopback = [{"device_interface": {"device": "node-9", "name": "Loopback0"}}]
+        cluster = {"ip_address": [{"ip_address": {"device": "node-9"}}]}
+        portchannel = [
+            {"device_interface": {"device": "node-9", "name": "PortChannel1"}}
+        ]
+        autoconf = {
+            "device": [],
+            "device_interface": [
+                {"device_interface": {"device": "node-9", "name": "Ethernet0"}}
+            ],
+            "ip_address": [],
+        }
+        _patch_generators(
+            monkeypatch,
+            loopback=loopback,
+            cluster=cluster,
+            portchannel=portchannel,
+            autoconf=autoconf,
+        )
+        spy = _WriteSpy(monkeypatch)
+
+        result = main._run_autoconf_for_devices({"node-0"}, "out")
+
+        assert result == 0
+        assert spy.calls == []
+
+    def test_returns_zero_when_generators_empty(self, monkeypatch):
+        _patch_generators(monkeypatch)
+        spy = _WriteSpy(monkeypatch)
+
+        result = main._run_autoconf_for_devices(None, "out")
+
+        assert result == 0
+        assert spy.calls == []


### PR DESCRIPTION
## Summary

Tier 6 of the #232 unit-test rollout: branch-level tests for the **autoconf data-collection helpers and the dispatcher** in `netbox_manager/main.py`. These functions walk a mocked `pynetbox.api` client to collect interface MAC and device IP assignments, assemble them into per-device autoconf tasks, and route the assembled `tasks_by_type` payload either to disk or to a dry-run preview.

Test-only change — no production code is touched. `1018` insertions across `tests/conftest.py` and two new test modules.

Closes #254

## Change set (in commit order)

### 1. `3b5db9c` Extend shared test factories with autoconf pynetbox shapes
Additive extensions to `tests/conftest.py`:
- `make_device` gains a `device_id` keyword (defaults to `None`, so Tier 1 callers are unaffected) — the `device.id` key `_generate_autoconf_tasks` builds its device dicts from.
- `make_interface` gains `name` / `interface_id` / `mac_address` / `mac_addresses` keywords — the attributes the autoconf collectors read (`mac_addresses` defaults to `[]` so the collector's falsy check works without a guard).
- New `make_autoconf_api` factory: a fake `pynetbox.api` client exposing exactly the three read-only endpoints the collectors touch — `dcim.devices.all()`, `dcim.interfaces.filter(device_id, name=...)`, and `ipam.ip_addresses.filter(assigned_object_id)`.

### 2. `98e98cb` Add unit tests for the autoconf collectors
`tests/unit/netbox_manager/test_autoconf_collect.py` — covers issue groups 1–3:
- `collect_interface_assignments`: virtual-interface skip, direct vs. fallback MAC resolution, no-MAC skip, emitted task shape, name-sorted ordering.
- `collect_ip_assignments_by_interface`: OOB vs. primary IPv4/IPv6 routing, per-device grouping and multi-IP merge, no-match / empty input, ordering.
- `_generate_autoconf_tasks`: switch/non-switch split, interface bucket over all devices, OOB+primary per-device merge, sorted device bucket, returned bucket keys.

### 3. `6c37692` Add unit tests for the autoconf dispatcher
`tests/unit/netbox_manager/test_autoconf_dispatch.py` — covers issue group 4 (`_run_autoconf_for_devices`) with the five generators patched to fixed task lists/dicts:
- interface-label merge (label side wins on overlap, autoconf-only passthrough, label-only leftovers appended last);
- `device`/`ip_address` bucket passthrough;
- device filter applied across every task source (plus the `None` case that keeps everything);
- dry-run preview returning `0` without writing;
- file-write path routing the assembled payload into `_write_autoconf_files` (spied, and once run for real over `tmp_path`);
- the two empty-after-filter / empty-generator short-circuits.

## Notes for the reviewer

- No divergence from the issue scope: the generators, `_write_autoconf_files` internals, and the pure Tier 1 helpers are out of scope and are patched/stubbed rather than exercised, as the issue directs.
- New shared fixtures are documented inline in `conftest.py` for reuse by later tiers (the docstring flags that #255 validation will add `ipam.prefixes` / `dcim.interfaces.get` on top of `make_autoconf_api`).

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 6b3f3ea with Claude:claude-opus-4-8_
