### PR TITLE
Unit tests: Tier 10 — CLI command wiring (smoke tests)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,13 +37,15 @@ os.environ.pop("NETBOX_MANAGER_SWITCH_ROLES", None)
 # `mac_address` / `mac_addresses` attributes the autoconf collectors read and
 # adds the `make_autoconf_api` fake `pynetbox.api` client for those collectors.
 # Next come the heavier `mock_ansible_runner` recorder and the loguru->`caplog`
-# bridge (Tier 4, #252). The Device Type Library seams (Tier 9, #257) -- the
-# fake `pynetbox.api` client (`make_dtl_api`), the `tmp_path` library-tree
-# builder (`make_dtl_tree`), the `LogHandler` call-through spy
-# (`dtl_log_handler`) and the raisable `pynetbox.RequestError` factory
-# (`make_request_error`) -- come next. The validation shape factories
-# `make_vrf` / `make_ip_address` (Tier 7, #255) -- feeding the read-only
-# `validate_ip_addresses_have_prefixes` / `validate_vrf_consistency` helpers --
+# bridge (Tier 4, #252). The `typer.testing.CliRunner` driver (`cli_runner`) and
+# the command worker-spy bundle (`mock_cli_workers`) for the CLI wiring smoke
+# tests (Tier 10, #258) come next. The Device Type Library seams (Tier 9, #257)
+# -- the fake `pynetbox.api` client (`make_dtl_api`), the `tmp_path` library-tree
+# builder (`make_dtl_tree`), the `LogHandler` call-through spy (`dtl_log_handler`)
+# and the raisable `pynetbox.RequestError` factory (`make_request_error`) -- come
+# next. The validation shape factories `make_vrf` / `make_ip_address` (Tier 7,
+# #255) -- feeding the read-only `validate_ip_addresses_have_prefixes` /
+# `validate_vrf_consistency` helpers --
 # close the file. The remaining heavy seams (`git.Repo`, `subprocess`) belong to
 # later #232 tiers.
 
@@ -479,6 +481,89 @@ def mock_ansible_runner(monkeypatch):
     return fake
 
 
+@pytest.fixture
+def cli_runner():
+    """Return a ``typer.testing.CliRunner`` for driving ``main.app``.
+
+    Invoke commands with an argument list --
+    ``cli_runner.invoke(app, ["run", "--dryrun"])`` -- and assert on
+    ``result.exit_code`` / ``result.output``. ``CliRunner`` is imported inside
+    the fixture body to preserve the env-vars-before-import discipline
+    established at the top of this module.
+
+    Shared with the Tier 10 (#258) command-wiring smoke tests; pair it with
+    :func:`mock_cli_workers` so no command reaches a live worker.
+    """
+    from typer.testing import CliRunner
+
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_cli_workers(monkeypatch):
+    """Patch every heavy worker behind ``main``'s Typer commands with a spy.
+
+    The Tier 10 (#258) command smoke tests exercise only the ``typer`` dispatch
+    surface -- option parsing, worker dispatch, exit codes -- so each heavy
+    worker is replaced with a :class:`unittest.mock.MagicMock`. With these in
+    place the ``run`` / ``autoconf`` / ``validate`` / ``purge`` command bodies
+    run to their seams without touching NetBox, ``ansible_runner``, ``git`` or
+    the real filesystem.
+
+    ``init_logger`` is spied for two reasons. First, the real one calls
+    ``logger.remove()`` (``main.py``), which drops the conftest
+    loguru->``caplog`` bridge mid-command and would blind ``caplog``
+    assertions. Second, the spy doubles as the ``--debug`` / ``--verbose``
+    plumbing assertion point -- those flags route through ``init_logger``.
+
+    Returns a :class:`types.SimpleNamespace` exposing each spy as an attribute:
+        run_main: ``main._run_main`` (the ``run`` command's pass-through
+            target).
+        run_autoconf_for_devices: ``main._run_autoconf_for_devices``
+            (``return_value=0`` so the "no tasks" branch is deterministic).
+        validate_ip_addresses_have_prefixes / validate_vrf_consistency: the two
+            ``validate`` checks (``return_value=(True, [])`` -- passed, no
+            findings).
+        validate_netbox_connection: the pre-flight connection guard (no-op).
+        create_netbox_api: the ``validate`` API-client factory.
+        init_logger: the logger initialiser (see above).
+
+    ``main`` is imported inside the fixture body to preserve the
+    env-vars-before-import discipline. Shared with the Tier 10 (#258) command
+    tests; extend it here rather than re-patching per test module. The ``purge``
+    command builds its own client via ``pynetbox.api`` (not
+    ``create_netbox_api``), so purge tests additionally patch
+    ``main.pynetbox.api`` themselves.
+    """
+    from unittest.mock import MagicMock
+
+    from netbox_manager import main
+
+    spies = SimpleNamespace(
+        run_main=MagicMock(),
+        run_autoconf_for_devices=MagicMock(return_value=0),
+        validate_ip_addresses_have_prefixes=MagicMock(return_value=(True, [])),
+        validate_vrf_consistency=MagicMock(return_value=(True, [])),
+        validate_netbox_connection=MagicMock(),
+        create_netbox_api=MagicMock(),
+        init_logger=MagicMock(),
+    )
+    targets = {
+        "_run_main": spies.run_main,
+        "_run_autoconf_for_devices": spies.run_autoconf_for_devices,
+        "validate_ip_addresses_have_prefixes": (
+            spies.validate_ip_addresses_have_prefixes
+        ),
+        "validate_vrf_consistency": spies.validate_vrf_consistency,
+        "validate_netbox_connection": spies.validate_netbox_connection,
+        "create_netbox_api": spies.create_netbox_api,
+        "init_logger": spies.init_logger,
+    }
+    for attr, spy in targets.items():
+        monkeypatch.setattr(main, attr, spy)
+    return spies
+
+
 # --- Device Type Library (dtl.py) seams, Tier 9 (#257) --------------------
 #
 # ``netbox_manager.dtl`` talks to NetBox only through ``pynetbox.api`` and to
@@ -729,12 +814,14 @@ def make_request_error():
     ``RequestError.__new__`` and sets ``.error`` / ``.message`` directly,
     deliberately bypassing the real ``__init__`` (which requires a live
     ``requests.Response`` object). ``.error`` is what ``dtl.py`` reads off a
-    caught ``RequestError``; ``.message`` backs ``RequestError.__str__`` so the
-    ``main.py`` validators (Tier 7, #255) can ``logger.error(f"... {e}")`` before
-    re-raising without tripping over the unset attribute. The instance is still
-    caught by ``except pynetbox.RequestError``. Set it as a ``FakeDtlEndpoint``'s
+    caught ``RequestError``; ``.message`` backs ``RequestError.__str__``, so it
+    must be set for consumers that stringify the exception -- the ``main.py``
+    validators (Tier 7, #255) ``logger.error(f"... {e}")`` before re-raising, and
+    the command handlers log ``f"NetBox API error: {e}"`` (Tier 10, #258) --
+    without tripping over the unset attribute. The instance is still caught by
+    ``except pynetbox.RequestError``. Set it as a ``FakeDtlEndpoint``'s
     ``create_error`` to drive the error branches. Shared with later #232 tiers
-    that assert error propagation.
+    that assert error propagation (#256, #258).
     """
     import pynetbox
 

--- a/tests/unit/netbox_manager/test_cli_commands.py
+++ b/tests/unit/netbox_manager/test_cli_commands.py
@@ -54,6 +54,42 @@ RUN_MAIN_DEFAULTS = (
 )
 
 
+class _FakeResource:
+    """A single purge target: a real ``name`` plus a spy ``delete``.
+
+    ``get_resource_name`` (main.py) reads ``name`` off the resource, so it must
+    be a real attribute (a bare ``MagicMock`` would not satisfy the ``name``
+    lookup). ``delete`` is a spy the tests assert was never called in dry-run.
+    """
+
+    def __init__(self, name):
+        self.name = name
+        self.delete = MagicMock()
+
+
+class _FakePurgeTree:
+    """Stand-in for the ``pynetbox.api(...)`` client used by ``purge_command``.
+
+    ``purge_command`` resolves each endpoint with a two-level ``getattr``
+    traversal (e.g. ``api.ipam.ip_addresses``); ``__getattr__`` returns ``self``
+    so any dotted path collapses back to this tree. ``all()`` records how many
+    times it was reached (``all_calls``) and returns the canned resources, which
+    lets the ``--limit`` narrowing tests assert on the number of endpoints
+    actually visited.
+    """
+
+    def __init__(self, resources):
+        self._resources = resources
+        self.all_calls = 0
+
+    def __getattr__(self, name):
+        return self
+
+    def all(self):
+        self.all_calls += 1
+        return list(self._resources)
+
+
 class TestRunCommand:
     """Group 1 -- ``run_command`` option mapping and dispatch (main.py)."""
 
@@ -217,3 +253,190 @@ class TestAutoconfCommand:
 
         assert result.exit_code == 1
         assert "Error generating autoconf" in caplog.text
+
+
+class TestValidateCommand:
+    """Group 3 -- ``validate_command`` check dispatch and exit codes (main.py)."""
+
+    def test_check_ip_prefixes_runs_only_ip_check(self, cli_runner, mock_cli_workers):
+        result = cli_runner.invoke(app, ["validate", "--check", "ip-prefixes"])
+
+        assert result.exit_code == 0
+        assert mock_cli_workers.validate_ip_addresses_have_prefixes.call_count == 1
+        assert mock_cli_workers.validate_ip_addresses_have_prefixes.call_args.args == (
+            mock_cli_workers.create_netbox_api.return_value,
+            False,
+        )
+        mock_cli_workers.validate_vrf_consistency.assert_not_called()
+
+    def test_check_vrf_consistency_runs_only_vrf_check(
+        self, cli_runner, mock_cli_workers
+    ):
+        result = cli_runner.invoke(app, ["validate", "--check", "vrf-consistency"])
+
+        assert result.exit_code == 0
+        assert mock_cli_workers.validate_vrf_consistency.call_count == 1
+        assert mock_cli_workers.validate_vrf_consistency.call_args.args == (
+            mock_cli_workers.create_netbox_api.return_value,
+            False,
+        )
+        mock_cli_workers.validate_ip_addresses_have_prefixes.assert_not_called()
+
+    def test_no_check_runs_both_and_exits_0_on_pass(
+        self, cli_runner, mock_cli_workers, caplog
+    ):
+        result = cli_runner.invoke(app, ["validate"])
+
+        assert result.exit_code == 0
+        assert mock_cli_workers.validate_ip_addresses_have_prefixes.call_count == 1
+        assert mock_cli_workers.validate_vrf_consistency.call_count == 1
+        # The inner ``typer.Exit(0)`` must escape the ``except typer.Exit:
+        # raise`` guard, not get mangled to exit 1 by the generic handler.
+        assert "Error during validation" not in caplog.text
+
+    def test_invalid_check_exits_1_before_any_worker(
+        self, cli_runner, mock_cli_workers, caplog
+    ):
+        result = cli_runner.invoke(app, ["validate", "--check", "foo"])
+
+        assert result.exit_code == 1
+        assert "Invalid check(s): foo" in caplog.text
+        mock_cli_workers.create_netbox_api.assert_not_called()
+        mock_cli_workers.validate_ip_addresses_have_prefixes.assert_not_called()
+        mock_cli_workers.validate_vrf_consistency.assert_not_called()
+
+    def test_ip_findings_exit_1(self, cli_runner, mock_cli_workers, caplog):
+        mock_cli_workers.validate_ip_addresses_have_prefixes.return_value = (
+            False,
+            [
+                {
+                    "address": "10.0.0.5/32",
+                    "vrf": "Global",
+                    "device": "node-0",
+                    "interface": "eth0",
+                    "assigned_object": "node-0",
+                    "reason": "No matching prefix found in same VRF",
+                }
+            ],
+        )
+
+        result = cli_runner.invoke(app, ["validate", "--check", "ip-prefixes"])
+
+        assert result.exit_code == 1
+        assert "IP-Prefix Check FAILED" in caplog.text
+
+    def test_vrf_findings_exit_1(self, cli_runner, mock_cli_workers, caplog):
+        mock_cli_workers.validate_vrf_consistency.return_value = (
+            False,
+            [
+                {
+                    "ip_address": "10.0.0.5/32",
+                    "ip_vrf": "red",
+                    "device": "node-0",
+                    "interface": "eth0",
+                    "interface_vrf": "blue",
+                    "reason": "VRF mismatch",
+                }
+            ],
+        )
+
+        result = cli_runner.invoke(app, ["validate", "--check", "vrf-consistency"])
+
+        assert result.exit_code == 1
+        assert "VRF Consistency Check FAILED" in caplog.text
+
+    def test_worker_request_error_exits_1(
+        self, cli_runner, mock_cli_workers, caplog, make_request_error
+    ):
+        mock_cli_workers.validate_ip_addresses_have_prefixes.side_effect = (
+            make_request_error()
+        )
+
+        result = cli_runner.invoke(app, ["validate", "--check", "ip-prefixes"])
+
+        assert result.exit_code == 1
+        assert "NetBox API error" in caplog.text
+
+    def test_worker_generic_error_exits_1(self, cli_runner, mock_cli_workers, caplog):
+        mock_cli_workers.validate_ip_addresses_have_prefixes.side_effect = RuntimeError(
+            "kaput"
+        )
+
+        result = cli_runner.invoke(app, ["validate", "--check", "ip-prefixes"])
+
+        assert result.exit_code == 1
+        assert "Error during validation" in caplog.text
+
+
+class TestPurgeCommand:
+    """Group 4 -- ``purge_command`` dry-run / confirmation gate (main.py).
+
+    Only the dry-run and confirmation gates are covered here; the real
+    destructive deletion path is out of scope for this tier. Every test asserts
+    the deletion worker recorded zero destructive calls.
+    """
+
+    def test_dryrun_skips_confirm_and_never_deletes(
+        self, cli_runner, mock_cli_workers, caplog, monkeypatch
+    ):
+        resources = [_FakeResource("a"), _FakeResource("b")]
+        tree = _FakePurgeTree(resources)
+        monkeypatch.setattr(main.pynetbox, "api", lambda *a, **k: tree)
+        confirm_spy = MagicMock()
+        monkeypatch.setattr(main.typer, "confirm", confirm_spy)
+
+        result = cli_runner.invoke(app, ["purge", "--dryrun"])
+
+        assert result.exit_code == 0
+        confirm_spy.assert_not_called()
+        assert all(r.delete.call_count == 0 for r in resources)
+        assert "Dry run complete - no resources were deleted" in caplog.text
+
+    def test_declined_confirmation_cancels_before_api_construction(
+        self, cli_runner, mock_cli_workers, caplog, monkeypatch
+    ):
+        monkeypatch.setattr(main.typer, "confirm", lambda *a, **k: False)
+        api_factory = MagicMock()
+        monkeypatch.setattr(main.pynetbox, "api", api_factory)
+
+        result = cli_runner.invoke(app, ["purge"])
+
+        assert result.exit_code == 0
+        assert "Purge cancelled by user" in caplog.text
+        # The client is only built *after* the confirmation gate, so declining
+        # leaves the destructive path unreachable.
+        api_factory.assert_not_called()
+
+    def test_unknown_limit_exits_1(
+        self, cli_runner, mock_cli_workers, caplog, monkeypatch
+    ):
+        resources = [_FakeResource("a"), _FakeResource("b")]
+        tree = _FakePurgeTree(resources)
+        monkeypatch.setattr(main.pynetbox, "api", lambda *a, **k: tree)
+
+        result = cli_runner.invoke(
+            app, ["purge", "--dryrun", "--limit", "does-not-exist"]
+        )
+
+        assert result.exit_code == 1
+        assert "No resource type matching 'does-not-exist' found" in caplog.text
+        assert tree.all_calls == 0
+        assert all(r.delete.call_count == 0 for r in resources)
+
+    def test_matching_limit_narrows_order(
+        self, cli_runner, mock_cli_workers, caplog, monkeypatch
+    ):
+        resources = [_FakeResource("10.0.0.1/32"), _FakeResource("10.0.0.2/32")]
+        tree = _FakePurgeTree(resources)
+        monkeypatch.setattr(main.pynetbox, "api", lambda *a, **k: tree)
+
+        result = cli_runner.invoke(
+            app, ["purge", "--dryrun", "--limit", "ip-addresses"]
+        )
+
+        assert result.exit_code == 0
+        # ``ip-addresses`` matches exactly one entry (ipam.ip_addresses), so the
+        # traversal reaches ``all()`` once.
+        assert tree.all_calls == 1
+        assert "Would delete 2 IP addresses" in caplog.text
+        assert all(r.delete.call_count == 0 for r in resources)

--- a/tests/unit/netbox_manager/test_cli_commands.py
+++ b/tests/unit/netbox_manager/test_cli_commands.py
@@ -23,8 +23,12 @@ mid-command and blind the log-message assertions; the spy also serves as the
 ``--debug`` / ``--verbose`` plumbing assertion point.
 """
 
+import signal
 from importlib import metadata
 from unittest.mock import MagicMock
+
+import pytest
+import typer
 
 from netbox_manager import main
 from netbox_manager.main import app
@@ -440,3 +444,101 @@ class TestPurgeCommand:
         assert tree.all_calls == 1
         assert "Would delete 2 IP addresses" in caplog.text
         assert all(r.delete.call_count == 0 for r in resources)
+
+
+class TestVersionCommand:
+    """Group 5 -- ``version_command`` prints and returns normally (main.py)."""
+
+    def test_prints_version_and_exits_0(self, cli_runner):
+        result = cli_runner.invoke(app, ["version"])
+
+        assert result.exit_code == 0
+        assert result.output == f"netbox-manager {VERSION}\n"
+
+    def test_returns_normally_without_typer_exit(self, capsys):
+        assert main.version_command() is None
+        assert capsys.readouterr().out == f"netbox-manager {VERSION}\n"
+
+
+class TestMainCallback:
+    """Group 5 -- ``main_callback`` no-subcommand default (main.py)."""
+
+    def test_no_subcommand_dispatches_to_run_command(
+        self, cli_runner, mock_cli_workers
+    ):
+        result = cli_runner.invoke(app, [])
+
+        assert result.exit_code == 0
+        assert mock_cli_workers.run_main.call_count == 1
+        assert mock_cli_workers.run_main.call_args.args == RUN_MAIN_DEFAULTS
+
+
+class TestMainEntrypoint:
+    """Group 5 -- ``main`` registers the SIGINT handler and runs the app."""
+
+    def test_registers_sigint_handler_and_invokes_app(self, monkeypatch):
+        signal_spy = MagicMock()
+        monkeypatch.setattr(main.signal, "signal", signal_spy)
+        app_mock = MagicMock()
+        monkeypatch.setattr(main, "app", app_mock)
+
+        main.main()
+
+        signal_spy.assert_called_once_with(signal.SIGINT, main.signal_handler_sigint)
+        app_mock.assert_called_once_with()
+
+
+class TestSignalHandlerSigint:
+    """Group 5 -- ``signal_handler_sigint`` prints and raises (main.py)."""
+
+    def test_prints_and_raises_typer_exit(self, capsys):
+        with pytest.raises(typer.Exit) as exc_info:
+            main.signal_handler_sigint(signal.SIGINT, None)
+
+        assert exc_info.value.exit_code == 0
+        assert capsys.readouterr().out == "SIGINT received. Exit.\n"
+
+
+class TestInitLogger:
+    """Group 5 -- ``init_logger`` level selection (main.py).
+
+    The real ``logger`` is replaced with a mock so the load-bearing
+    ``logger.remove()`` cannot tear down the shared caplog bridge; this also
+    exposes the sink wiring (``remove`` then ``add``) for assertion.
+    """
+
+    def test_debug_selects_debug_level(self, monkeypatch):
+        logger_mock = MagicMock()
+        monkeypatch.setattr(main, "logger", logger_mock)
+
+        main.init_logger(True)
+
+        logger_mock.remove.assert_called_once_with()
+        assert logger_mock.add.call_count == 1
+        assert logger_mock.add.call_args.args[0] is main.sys.stderr
+        assert logger_mock.add.call_args.kwargs["level"] == "DEBUG"
+
+    def test_default_selects_info_level(self, monkeypatch):
+        logger_mock = MagicMock()
+        monkeypatch.setattr(main, "logger", logger_mock)
+
+        main.init_logger(False)
+
+        logger_mock.remove.assert_called_once_with()
+        assert logger_mock.add.call_count == 1
+        assert logger_mock.add.call_args.kwargs["level"] == "INFO"
+
+
+class TestCallbackVersion:
+    """Group 5 -- ``callback_version`` eager option branches (main.py)."""
+
+    def test_true_prints_and_exits(self, capsys):
+        with pytest.raises(typer.Exit) as exc_info:
+            main.callback_version(True)
+
+        assert exc_info.value.exit_code == 0
+        assert capsys.readouterr().out == f"Version {VERSION}\n"
+
+    def test_false_is_noop(self, capsys):
+        assert main.callback_version(False) is None
+        assert capsys.readouterr().out == ""

--- a/tests/unit/netbox_manager/test_cli_commands.py
+++ b/tests/unit/netbox_manager/test_cli_commands.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke tests for the Typer command wiring (issue #258, Tier 10 of #232).
+
+This tier covers the thin ``@app.command()`` / ``@app.callback()`` shells in
+``netbox_manager.main`` plus the entrypoint plumbing (``main``, the SIGINT
+handler, ``init_logger``, the ``--version`` eager callback). The goal is to
+verify that CLI argument/option parsing maps onto the right worker arguments,
+that each command dispatches to the correct worker, and that exit codes are
+correct -- *not* to re-test the workers themselves (Tiers 1-9 do that).
+
+The defining property of this tier is that every heavy worker is patched out
+via the shared ``mock_cli_workers`` fixture (see ``conftest.py``): ``_run_main``,
+``_run_autoconf_for_devices``, ``validate_ip_addresses_have_prefixes`` /
+``validate_vrf_consistency``, the connection guard and the API factory. As a
+result these tests touch no live NetBox, no ``ansible_runner``, no ``git.Repo``
+and no real filesystem -- they exercise only the ``typer`` dispatch surface, and
+the destructive ``purge`` deletion path is asserted unreached in dry-run.
+
+``init_logger`` is among the patched workers because the real one calls
+``logger.remove()``, which would tear down the shared loguru->``caplog`` bridge
+mid-command and blind the log-message assertions; the spy also serves as the
+``--debug`` / ``--verbose`` plumbing assertion point.
+"""
+
+from importlib import metadata
+from unittest.mock import MagicMock
+
+from netbox_manager import main
+from netbox_manager.main import app
+
+VERSION = metadata.version("netbox-manager")
+
+# ``_run_main`` receives all 17 ``run`` options positionally (main.py). This is
+# the tuple ``run`` forwards for a bare ``run`` / no-subcommand invocation.
+RUN_MAIN_DEFAULTS = (
+    True,  # always
+    False,  # debug
+    False,  # dryrun
+    None,  # limit
+    1,  # parallel
+    None,  # version
+    False,  # skipdtl
+    False,  # skipmtl
+    False,  # skipres
+    True,  # wait
+    None,  # filter_task
+    False,  # include_ignored_files
+    None,  # filter_device
+    False,  # fail_fast
+    False,  # show_playbooks
+    False,  # verbose
+    False,  # ignore_errors
+)
+
+
+class TestRunCommand:
+    """Group 1 -- ``run_command`` option mapping and dispatch (main.py)."""
+
+    def test_options_map_positionally_to_run_main(self, cli_runner, mock_cli_workers):
+        result = cli_runner.invoke(
+            app,
+            [
+                "run",
+                "--no-always",
+                "--dryrun",
+                "--limit",
+                "300",
+                "--parallel",
+                "4",
+                "--skipdtl",
+                "--skipmtl",
+                "--skipres",
+                "--no-wait",
+                "--filter-task",
+                "device",
+                "--filter-device",
+                "node-a",
+                "--filter-device",
+                "node-b",
+                "--fail-fast",
+                "--show-playbooks",
+                "--verbose",
+                "--ignore-errors",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert mock_cli_workers.run_main.call_count == 1
+        assert mock_cli_workers.run_main.call_args.kwargs == {}
+        assert mock_cli_workers.run_main.call_args.args == (
+            False,  # always (--no-always)
+            False,  # debug
+            True,  # dryrun
+            "300",  # limit
+            4,  # parallel
+            None,  # version
+            True,  # skipdtl
+            True,  # skipmtl
+            True,  # skipres
+            False,  # wait (--no-wait)
+            "device",  # filter_task
+            False,  # include_ignored_files
+            ["node-a", "node-b"],  # filter_device (repeatable -> list)
+            True,  # fail_fast
+            True,  # show_playbooks
+            True,  # verbose
+            True,  # ignore_errors
+        )
+
+    def test_bare_run_uses_documented_defaults(self, cli_runner, mock_cli_workers):
+        result = cli_runner.invoke(app, ["run"])
+
+        assert result.exit_code == 0
+        assert mock_cli_workers.run_main.call_count == 1
+        assert mock_cli_workers.run_main.call_args.args == RUN_MAIN_DEFAULTS
+
+    def test_dispatch_touches_only_the_patched_worker(
+        self, cli_runner, mock_cli_workers, mock_ansible_runner
+    ):
+        result = cli_runner.invoke(app, ["run"])
+
+        assert result.exit_code == 0
+        # The connection guard and the API factory both live *inside* the
+        # patched ``_run_main``, so a hermetic dispatch never reaches them.
+        mock_cli_workers.validate_netbox_connection.assert_not_called()
+        mock_cli_workers.create_netbox_api.assert_not_called()
+        assert mock_ansible_runner.calls == []
+
+    def test_version_eager_callback_skips_run_main(self, cli_runner, mock_cli_workers):
+        result = cli_runner.invoke(app, ["run", "--version"])
+
+        assert result.exit_code == 0
+        assert f"Version {VERSION}" in result.output
+        mock_cli_workers.run_main.assert_not_called()
+
+
+class TestAutoconfCommand:
+    """Group 2 -- ``autoconf_command`` dispatch and exit codes (main.py)."""
+
+    def test_flat_mode_dispatches_worker_once(
+        self, cli_runner, mock_cli_workers, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(main.settings, "RESOURCES", str(tmp_path), raising=False)
+        detect = MagicMock(return_value={})
+        monkeypatch.setattr(main, "detect_site_folders", detect)
+
+        result = cli_runner.invoke(app, ["autoconf"])
+
+        assert result.exit_code == 0
+        detect.assert_called_once_with(str(tmp_path))
+        assert mock_cli_workers.run_autoconf_for_devices.call_count == 1
+        assert mock_cli_workers.run_autoconf_for_devices.call_args.kwargs == {
+            "device_filter": None,
+            "output_dir": str(tmp_path),
+            "prefix": "999-autoconf",
+            "dryrun": False,
+        }
+        mock_cli_workers.validate_netbox_connection.assert_called_once_with()
+
+    def test_output_option_derives_prefix_and_output_dir(
+        self, cli_runner, mock_cli_workers, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(main.settings, "RESOURCES", str(tmp_path), raising=False)
+        monkeypatch.setattr(main, "detect_site_folders", MagicMock(return_value={}))
+
+        result = cli_runner.invoke(
+            app, ["autoconf", "--output", "sub/dir/500-site.yml"]
+        )
+
+        assert result.exit_code == 0
+        kwargs = mock_cli_workers.run_autoconf_for_devices.call_args.kwargs
+        assert kwargs["prefix"] == "500-site"
+        assert kwargs["output_dir"] == "sub/dir"
+
+    def test_dryrun_and_debug_plumbing(
+        self, cli_runner, mock_cli_workers, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(main.settings, "RESOURCES", str(tmp_path), raising=False)
+        monkeypatch.setattr(main, "detect_site_folders", MagicMock(return_value={}))
+
+        result = cli_runner.invoke(app, ["autoconf", "--dryrun", "--debug"])
+
+        assert result.exit_code == 0
+        kwargs = mock_cli_workers.run_autoconf_for_devices.call_args.kwargs
+        assert kwargs["dryrun"] is True
+        mock_cli_workers.init_logger.assert_called_once_with(True)
+
+    def test_request_error_from_worker_exits_1(
+        self,
+        cli_runner,
+        mock_cli_workers,
+        monkeypatch,
+        tmp_path,
+        caplog,
+        make_request_error,
+    ):
+        monkeypatch.setattr(main.settings, "RESOURCES", str(tmp_path), raising=False)
+        monkeypatch.setattr(main, "detect_site_folders", MagicMock(return_value={}))
+        mock_cli_workers.run_autoconf_for_devices.side_effect = make_request_error(
+            "boom"
+        )
+
+        result = cli_runner.invoke(app, ["autoconf"])
+
+        assert result.exit_code == 1
+        assert "NetBox API error" in caplog.text
+
+    def test_generic_error_from_worker_exits_1(
+        self, cli_runner, mock_cli_workers, monkeypatch, tmp_path, caplog
+    ):
+        monkeypatch.setattr(main.settings, "RESOURCES", str(tmp_path), raising=False)
+        monkeypatch.setattr(main, "detect_site_folders", MagicMock(return_value={}))
+        mock_cli_workers.run_autoconf_for_devices.side_effect = RuntimeError("kaput")
+
+        result = cli_runner.invoke(app, ["autoconf"])
+
+        assert result.exit_code == 1
+        assert "Error generating autoconf" in caplog.text


### PR DESCRIPTION
Closes #258

## Tier 10 (of #232) — CLI command wiring smoke tests

This branch adds smoke tests that drive the Typer commands in
`netbox_manager/main.py` through their dispatch surface — option parsing,
worker dispatch, and exit codes — without touching NetBox, `ansible_runner`,
`git`, or the real filesystem. It is **test-only**: no production code is
changed. Two files are touched — `tests/conftest.py` (+115) and a new
`tests/unit/netbox_manager/test_cli_commands.py` (+544).

### Change set, in commit order

1. **`71591a2` Add shared CLI runner and worker-spy fixtures for command tests**
   Adds two shared fixtures to `tests/conftest.py`:
   - `cli_runner` — a `typer.testing.CliRunner` for invoking `main.app`.
   - `mock_cli_workers` — replaces every heavy worker (`_run_main`,
     `_run_autoconf_for_devices`, both `validate_*` checks,
     `validate_netbox_connection`, `create_netbox_api`, `init_logger`) with
     `MagicMock` spies, returned as a `SimpleNamespace`. `init_logger` is spied
     both so the real `logger.remove()` cannot tear down the conftest
     loguru→`caplog` bridge mid-command, and as the assertion point for
     `--debug` / `--verbose` plumbing.

     Also sets `.message` on the fake `make_request_error` exception (alongside
     the existing `.error`) so it can be stringified — `RequestError.__str__`
     returns `self.message`, and the `main.py` handlers log
     `f"NetBox API error: {e}"`. The dtl tiers read `.error`, which is unchanged.

2. **`73b2a3b` Add smoke tests for run and autoconf command wiring**
   `run_command`: the 17 options map positionally into the patched `_run_main`
   (including repeatable `--filter-device`); a bare `run` forwards the documented
   defaults; dispatch touches no worker outside the patched `_run_main`; and
   `--version` fires the eager callback without running the body.
   `autoconf_command`: flat-mode dispatch, `--output` prefix/dir derivation,
   `--dryrun` / `--debug` plumbing, and `RequestError` / generic worker errors
   exit 1.

3. **`ea84ea5` Add smoke tests for validate and purge command wiring**
   `validate_command`: per-check dispatch (`--check ip-prefixes` /
   `vrf-consistency` run only their own check, no `--check` runs both), an
   unknown check exits 1 before any worker, and the non-zero-on-findings
   contract (passed checks exit 0; findings and worker errors exit 1; an inner
   `typer.Exit` is re-raised unchanged).
   `purge_command`: the dry-run / confirmation gate only — dry-run skips the
   confirmation and records zero deletions, a declined confirmation cancels
   before the API client is built, and `--limit` narrows (matching) or empties
   and exits 1 (unknown). A module-local fake `pynetbox` tree keeps the
   destructive path unreached.

4. **`6ee0536` Add smoke tests for entrypoint and utility wiring**
   Covers the remaining seams: `version_command` prints and returns without
   `typer.Exit`; `main_callback` with no subcommand dispatches to `run_command`
   with documented defaults; `main` registers `signal_handler_sigint` for SIGINT
   and calls `app()`; `signal_handler_sigint` prints and raises `typer.Exit(0)`;
   `init_logger` selects DEBUG vs INFO and wires `logger.remove()` then
   `logger.add(...)`; and `callback_version` prints + exits on True, no-op on
   False.

### Divergences from the issue

None observed. The commits track the Tier 10 scope directly (the `run`,
`autoconf`, `validate`, `purge`, entrypoint, and utility command groups), and
the work stays within the smoke-test remit — asserting dispatch, option
plumbing, and exit codes rather than the workers' internal behavior.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 6b3f3ea with Claude:claude-opus-4-8_
