### PR TITLE
Fix PortChannel name collision and keep numbers stable

### DIFF
--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -1986,6 +1986,23 @@ def _generate_portchannel_tasks() -> List[Dict[str, Any]]:
                         f"{connected_device.name}:{endpoint.name}"
                     )
 
+    # Track PortChannel numbers already assigned per device. The number is
+    # derived per switch pair, but a PortChannel name must be unique per device:
+    # when one switch participates in several pairs whose member interfaces
+    # extract to the same number (e.g. modular names like Ethernet3/1 and
+    # Ethernet4/1 both -> 1, or digit-less names both -> 0), the later pair would
+    # otherwise collide on the same name. Disambiguate by bumping to the next
+    # free number on that device.
+    used_portchannel_numbers: Dict[str, Set[int]] = {}
+
+    def assign_portchannel_number(device_name: str, desired: int) -> int:
+        used = used_portchannel_numbers.setdefault(device_name, set())
+        number = desired
+        while number in used:
+            number += 1
+        used.add(number)
+        return number
+
     # Process switch pairs with multiple connections in sorted order
     for switch_pair in sorted(switch_connections.keys()):
         connections = switch_connections[switch_pair]
@@ -2039,16 +2056,18 @@ def _generate_portchannel_tasks() -> List[Dict[str, Any]]:
         switch1_port_numbers = [
             extract_portchannel_number(name) for name in switch1_interfaces
         ]
-        switch1_portchannel_number = (
-            min(switch1_port_numbers) if switch1_port_numbers else 1
+        switch1_portchannel_number = assign_portchannel_number(
+            switch1_name,
+            min(switch1_port_numbers) if switch1_port_numbers else 1,
         )
         switch1_portchannel_name = f"PortChannel{switch1_portchannel_number}"
 
         switch2_port_numbers = [
             extract_portchannel_number(name) for name in switch2_interfaces
         ]
-        switch2_portchannel_number = (
-            min(switch2_port_numbers) if switch2_port_numbers else 1
+        switch2_portchannel_number = assign_portchannel_number(
+            switch2_name,
+            min(switch2_port_numbers) if switch2_port_numbers else 1,
         )
         switch2_portchannel_name = f"PortChannel{switch2_portchannel_number}"
 

--- a/netbox_manager/main.py
+++ b/netbox_manager/main.py
@@ -1924,16 +1924,41 @@ def _generate_portchannel_tasks() -> List[Dict[str, Any]]:
 
     logger.info(f"Found {len(switch_devices)} switch devices")
 
+    def parse_portchannel_number(name: Optional[str]) -> Optional[int]:
+        match = re.fullmatch(r"PortChannel(\d+)", name or "")
+        return int(match.group(1)) if match else None
+
     # Track connections between switches
     # Key: tuple of (switch1_name, switch2_name) where switch1_name < switch2_name
     # Value: list of tuples (switch1_interface, switch2_interface)
     switch_connections: Dict[Tuple[str, str], List[Tuple[Any, Any]]] = {}
 
+    # Collect existing PortChannel assignments per device (populated in the loop
+    # below before the cable/endpoint gates skip LAG interfaces).
+    existing_lag_numbers: Dict[str, Set[int]] = {}
+    member_to_number: Dict[str, Dict[str, int]] = {}
+
     # Analyze connections for each switch
     for switch in switch_devices:
-        interfaces = netbox_api.dcim.interfaces.filter(device_id=switch.id)
+        interfaces = list(netbox_api.dcim.interfaces.filter(device_id=switch.id))
 
         for interface in interfaces:
+            # Collect existing LAG interfaces and member back-references before
+            # the cable/endpoint gates: LAGs are virtual (uncabled) and would
+            # otherwise be silently skipped.
+            iface_type = getattr(interface, "type", None)
+            if getattr(iface_type, "value", None) == "lag":
+                number = parse_portchannel_number(interface.name)
+                if number is not None:
+                    existing_lag_numbers.setdefault(switch.name, set()).add(number)
+            member_lag = getattr(interface, "lag", None)
+            if member_lag is not None:
+                number = parse_portchannel_number(getattr(member_lag, "name", None))
+                if number is not None:
+                    member_to_number.setdefault(switch.name, {})[
+                        interface.name
+                    ] = number
+
             # Skip if no cable connection
             if not (hasattr(interface, "cable") and interface.cable):
                 continue
@@ -1993,10 +2018,31 @@ def _generate_portchannel_tasks() -> List[Dict[str, Any]]:
     # Ethernet4/1 both -> 1, or digit-less names both -> 0), the later pair would
     # otherwise collide on the same name. Disambiguate by bumping to the next
     # free number on that device.
-    used_portchannel_numbers: Dict[str, Set[int]] = {}
+    # Pre-seeded with numbers already held by existing PortChannel LAGs so that
+    # genuinely new channels never grab a number an existing LAG already holds,
+    # and so that surviving channels can reuse their existing number via
+    # member_to_number (read back from interface.lag in the loop above).
+    used_portchannel_numbers: Dict[str, Set[int]] = {
+        device: set(numbers) for device, numbers in existing_lag_numbers.items()
+    }
 
-    def assign_portchannel_number(device_name: str, desired: int) -> int:
+    def assign_portchannel_number(
+        device_name: str, desired: int, member_names: List[str]
+    ) -> int:
         used = used_portchannel_numbers.setdefault(device_name, set())
+        device_members = member_to_number.get(device_name, {})
+        existing = {
+            device_members[name] for name in member_names if name in device_members
+        }
+        if existing:
+            number = min(existing)
+            if len(existing) > 1:
+                logger.warning(
+                    f"Members of a PortChannel on {device_name} map to multiple "
+                    f"existing LAG numbers {sorted(existing)}; reusing {number}"
+                )
+            used.add(number)
+            return number
         number = desired
         while number in used:
             number += 1
@@ -2059,6 +2105,7 @@ def _generate_portchannel_tasks() -> List[Dict[str, Any]]:
         switch1_portchannel_number = assign_portchannel_number(
             switch1_name,
             min(switch1_port_numbers) if switch1_port_numbers else 1,
+            switch1_interfaces,
         )
         switch1_portchannel_name = f"PortChannel{switch1_portchannel_number}"
 
@@ -2068,6 +2115,7 @@ def _generate_portchannel_tasks() -> List[Dict[str, Any]]:
         switch2_portchannel_number = assign_portchannel_number(
             switch2_name,
             min(switch2_port_numbers) if switch2_port_numbers else 1,
+            switch2_interfaces,
         )
         switch2_portchannel_name = f"PortChannel{switch2_portchannel_number}"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,11 @@ def make_interface():
             attribute (build entries inline as
             ``SimpleNamespace(mac_address=...)``); defaults to ``[]`` so the
             falsy check in the collector works without a guard.
+        lag: the member interface's back-reference to its LAG -- a bag
+            exposing ``.name`` (e.g.
+            ``SimpleNamespace(name="PortChannel2")``), or ``None`` (default)
+            for a non-member interface. The PortChannel generator reads it to
+            preserve an existing LAG's number across runs.
 
     Shared with later #232 test tiers.
     """
@@ -181,6 +186,7 @@ def make_interface():
         device=None,
         mac_address=None,
         mac_addresses=None,
+        lag=None,
     ):
         if type_value is None and type_label is None:
             interface_type = None
@@ -199,6 +205,7 @@ def make_interface():
             device=device,
             mac_address=mac_address,
             mac_addresses=[] if mac_addresses is None else mac_addresses,
+            lag=lag,
         )
 
     return _make_interface

--- a/tests/unit/netbox_manager/test_portchannel_tasks.py
+++ b/tests/unit/netbox_manager/test_portchannel_tasks.py
@@ -384,6 +384,81 @@ def test_shared_switch_colliding_digitless_names_get_distinct_lags(
     assert _lag_names_for(tasks, "sw-c") == ["PortChannel0", "PortChannel1"]
 
 
+def test_existing_lag_number_is_reused_for_surviving_channel(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    # sw-c sits in two pairs. The sw-a<->sw-c pair is removed; only sw-b<->sw-c
+    # remains. sw-c's surviving members (Ethernet4/1, Ethernet4/2) previously
+    # belonged to PortChannel2. Without stateful numbering they would derive 1
+    # (second number in the slashed name) and take PortChannel1, silently
+    # shifting the name. With stateful numbering the existing LAG number is
+    # reused and the name stays PortChannel2.
+    from types import SimpleNamespace
+
+    sw_b = make_device(name="sw-b", role_slug="leaf", device_id=2)
+    sw_c = make_device(name="sw-c", role_slug="leaf", device_id=3)
+    pc = make_interface(
+        name="PortChannel2", type_value="lag", interface_id=390, device=sw_c
+    )
+    c1 = make_interface(
+        name="Ethernet4/1",
+        interface_id=341,
+        device=sw_c,
+        lag=SimpleNamespace(name="PortChannel2"),
+    )
+    c2 = make_interface(
+        name="Ethernet4/2",
+        interface_id=342,
+        device=sw_c,
+        lag=SimpleNamespace(name="PortChannel2"),
+    )
+    b1 = _iface(make_interface, device=sw_b, name="Ethernet1", interface_id=201)
+    b2 = _iface(make_interface, device=sw_b, name="Ethernet2", interface_id=202)
+    _link(b1, c1)
+    _link(b2, c2)
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[sw_b, sw_c],
+        interfaces_by_device={2: [b1, b2], 3: [c1, c2, pc]},
+    )
+
+    tasks = main._generate_portchannel_tasks()
+
+    assert _lag_names_for(tasks, "sw-c") == ["PortChannel2"]
+
+
+def test_new_channel_avoids_existing_lag_number(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    # sw-c already has PortChannel1 (no members participating this run).
+    # A newly cabled sw-b<->sw-c pair whose sw-c members carry no lag yet and
+    # extract to 1 must bump past PortChannel1 to PortChannel2.
+    sw_b = make_device(name="sw-b", role_slug="leaf", device_id=2)
+    sw_c = make_device(name="sw-c", role_slug="leaf", device_id=3)
+    pc = make_interface(
+        name="PortChannel1", type_value="lag", interface_id=391, device=sw_c
+    )
+    c1 = make_interface(name="Ethernet1", interface_id=311, device=sw_c)
+    c2 = make_interface(name="Ethernet2", interface_id=312, device=sw_c)
+    b1 = _iface(make_interface, device=sw_b, name="Ethernet1", interface_id=201)
+    b2 = _iface(make_interface, device=sw_b, name="Ethernet2", interface_id=202)
+    _link(b1, c1)
+    _link(b2, c2)
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[sw_b, sw_c],
+        interfaces_by_device={2: [b1, b2], 3: [c1, c2, pc]},
+    )
+
+    tasks = main._generate_portchannel_tasks()
+
+    lag_tasks_sw_c = _lag_names_for(tasks, "sw-c")
+    assert len(lag_tasks_sw_c) == 1
+    assert lag_tasks_sw_c == ["PortChannel2"]
+
+
 def test_lag_tasks_precede_members_each_sorted_by_device_and_name(
     roles, monkeypatch, make_netbox_api, make_device, make_interface
 ):

--- a/tests/unit/netbox_manager/test_portchannel_tasks.py
+++ b/tests/unit/netbox_manager/test_portchannel_tasks.py
@@ -239,6 +239,151 @@ def test_portchannel_number_zero_when_no_digits(
     assert lag_names == {("sw-a", "PortChannel0"), ("sw-b", "PortChannel0")}
 
 
+def _lag_names_for(tasks, device):
+    """Return the sorted PortChannel names of LAG-creation tasks on ``device``."""
+    return sorted(
+        t["device_interface"]["name"]
+        for t in tasks
+        if t["device_interface"].get("type") == "lag"
+        and t["device_interface"]["device"] == device
+    )
+
+
+def test_shared_switch_colliding_slashed_names_get_distinct_lags(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    # sw-c sits in two pairs. Arista/Dell modular naming makes both pairs'
+    # members on sw-c extract to the same second number (1), so the per-pair
+    # numbering wants PortChannel1 on sw-c twice -- a name collision on one
+    # device. The two LAGs must instead be disambiguated to distinct names.
+    sw_a = make_device(name="sw-a", role_slug="leaf", device_id=1)
+    sw_b = make_device(name="sw-b", role_slug="leaf", device_id=2)
+    sw_c = make_device(name="sw-c", role_slug="leaf", device_id=3)
+    a1 = _iface(make_interface, device=sw_a, name="Ethernet1", interface_id=101)
+    a2 = _iface(make_interface, device=sw_a, name="Ethernet2", interface_id=102)
+    b1 = _iface(make_interface, device=sw_b, name="Ethernet1", interface_id=201)
+    b2 = _iface(make_interface, device=sw_b, name="Ethernet2", interface_id=202)
+    c_a1 = _iface(make_interface, device=sw_c, name="Ethernet3/1", interface_id=331)
+    c_a2 = _iface(make_interface, device=sw_c, name="Ethernet3/2", interface_id=332)
+    c_b1 = _iface(make_interface, device=sw_c, name="Ethernet4/1", interface_id=341)
+    c_b2 = _iface(make_interface, device=sw_c, name="Ethernet4/2", interface_id=342)
+    _link(a1, c_a1)
+    _link(a2, c_a2)
+    _link(b1, c_b1)
+    _link(b2, c_b2)
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[sw_a, sw_b, sw_c],
+        interfaces_by_device={
+            1: [a1, a2],
+            2: [b1, b2],
+            3: [c_a1, c_a2, c_b1, c_b2],
+        },
+    )
+
+    tasks = main._generate_portchannel_tasks()
+
+    # Pairs are processed in sorted order: (sw-a, sw-c) keeps the natural
+    # PortChannel1; (sw-b, sw-c) collides and is bumped to PortChannel2. Each
+    # peer keeps its own independent PortChannel1.
+    assert tasks == [
+        _lag_task("sw-a", "PortChannel1"),
+        _lag_task("sw-b", "PortChannel1"),
+        _lag_task("sw-c", "PortChannel1"),
+        _lag_task("sw-c", "PortChannel2"),
+        _member_task("sw-a", "Ethernet1", "PortChannel1"),
+        _member_task("sw-a", "Ethernet2", "PortChannel1"),
+        _member_task("sw-b", "Ethernet1", "PortChannel1"),
+        _member_task("sw-b", "Ethernet2", "PortChannel1"),
+        _member_task("sw-c", "Ethernet3/1", "PortChannel1"),
+        _member_task("sw-c", "Ethernet3/2", "PortChannel1"),
+        _member_task("sw-c", "Ethernet4/1", "PortChannel2"),
+        _member_task("sw-c", "Ethernet4/2", "PortChannel2"),
+    ]
+
+
+def test_shared_switch_colliding_cisco_names_get_distinct_lags(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    # Cisco stackable naming: the second number is the (identical) linecard
+    # index 0, so both pairs on sw-c want PortChannel0. They must resolve to two
+    # distinct names.
+    sw_a = make_device(name="sw-a", role_slug="leaf", device_id=1)
+    sw_b = make_device(name="sw-b", role_slug="leaf", device_id=2)
+    sw_c = make_device(name="sw-c", role_slug="leaf", device_id=3)
+    a1 = _iface(make_interface, device=sw_a, name="Ethernet1", interface_id=101)
+    a2 = _iface(make_interface, device=sw_a, name="Ethernet2", interface_id=102)
+    b1 = _iface(make_interface, device=sw_b, name="Ethernet1", interface_id=201)
+    b2 = _iface(make_interface, device=sw_b, name="Ethernet2", interface_id=202)
+    c_a1 = _iface(
+        make_interface, device=sw_c, name="GigabitEthernet1/0/1", interface_id=311
+    )
+    c_a2 = _iface(
+        make_interface, device=sw_c, name="GigabitEthernet1/0/2", interface_id=312
+    )
+    c_b1 = _iface(
+        make_interface, device=sw_c, name="GigabitEthernet2/0/1", interface_id=321
+    )
+    c_b2 = _iface(
+        make_interface, device=sw_c, name="GigabitEthernet2/0/2", interface_id=322
+    )
+    _link(a1, c_a1)
+    _link(a2, c_a2)
+    _link(b1, c_b1)
+    _link(b2, c_b2)
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[sw_a, sw_b, sw_c],
+        interfaces_by_device={
+            1: [a1, a2],
+            2: [b1, b2],
+            3: [c_a1, c_a2, c_b1, c_b2],
+        },
+    )
+
+    tasks = main._generate_portchannel_tasks()
+
+    assert _lag_names_for(tasks, "sw-c") == ["PortChannel0", "PortChannel1"]
+
+
+def test_shared_switch_colliding_digitless_names_get_distinct_lags(
+    roles, monkeypatch, make_netbox_api, make_device, make_interface
+):
+    # The review's literal case, now actually shared on one switch: digit-less
+    # names all extract to 0, so both pairs on sw-c want PortChannel0.
+    sw_a = make_device(name="sw-a", role_slug="leaf", device_id=1)
+    sw_b = make_device(name="sw-b", role_slug="leaf", device_id=2)
+    sw_c = make_device(name="sw-c", role_slug="leaf", device_id=3)
+    a1 = _iface(make_interface, device=sw_a, name="Ethernet1", interface_id=101)
+    a2 = _iface(make_interface, device=sw_a, name="Ethernet2", interface_id=102)
+    b1 = _iface(make_interface, device=sw_b, name="Ethernet1", interface_id=201)
+    b2 = _iface(make_interface, device=sw_b, name="Ethernet2", interface_id=202)
+    c_a1 = _iface(make_interface, device=sw_c, name="uplinkA", interface_id=311)
+    c_a2 = _iface(make_interface, device=sw_c, name="uplinkB", interface_id=312)
+    c_b1 = _iface(make_interface, device=sw_c, name="uplinkC", interface_id=321)
+    c_b2 = _iface(make_interface, device=sw_c, name="uplinkD", interface_id=322)
+    _link(a1, c_a1)
+    _link(a2, c_a2)
+    _link(b1, c_b1)
+    _link(b2, c_b2)
+    _wire(
+        monkeypatch,
+        make_netbox_api,
+        devices=[sw_a, sw_b, sw_c],
+        interfaces_by_device={
+            1: [a1, a2],
+            2: [b1, b2],
+            3: [c_a1, c_a2, c_b1, c_b2],
+        },
+    )
+
+    tasks = main._generate_portchannel_tasks()
+
+    assert _lag_names_for(tasks, "sw-c") == ["PortChannel0", "PortChannel1"]
+
+
 def test_lag_tasks_precede_members_each_sorted_by_device_and_name(
     roles, monkeypatch, make_netbox_api, make_device, make_interface
 ):


### PR DESCRIPTION
## Problem

`_generate_portchannel_tasks` derives the PortChannel number **per switch pair** from the lowest member interface number, but a PortChannel name must be unique **per device**. When one switch participates in several pairs whose member interfaces extract to the same number, every such pair produced the same PortChannel name on that switch — a name collision that merges distinct LAGs into one.

This is broader than the digit-less `→ 0` case: modular vendor names collapse too.

- Arista/Dell `Ethernet3/1` and `Ethernet4/1` both extract to the second number `1`.
- Cisco `GigabitEthernet1/0/1` and `GigabitEthernet2/0/1` both extract to `0`.

So two pairs on a shared switch both request `PortChannel1` (resp. `PortChannel0`). The flat `EthernetN` naming used by the testbed cannot collide, which is why the bug stayed latent — real vendor naming schemes hit it.

### Follow-up: names must also stay stable across runs

Fixing the collision by bumping to the next free number is not enough on its own. The number is recomputed from cabling on **every run**, and the bump is order-dependent, so removing one channel can silently **shift** the name of an untouched survivor. Example: `sw-c` sits in two pairs both deriving `1`; run 1 gives `PortChannel1` and (bumped) `PortChannel2`. Remove the first pair, and on the next run the survivor derives `1` again with nothing to collide against — its name moves `PortChannel2 → PortChannel1`. Because `device_interface` tasks key on **name**, the shifted name does not rename in place: it creates a new LAG and orphans the old one, churning a device that was not even touched.

Raised in review by @berendt.

## Fix

Make the per-device numbering both collision-free **and** stable:

- **Collision-free:** track the PortChannel numbers already assigned per device this run; when the derived number is already taken, bump to the next free number. Processing order is deterministic (pairs handled in sorted order).
- **Stable across runs:** read the PortChannel assignments already in NetBox and reuse them. In the pass that already fetches each switch's interfaces (no extra API calls), collect existing `PortChannel<N>` LAG numbers and a member-interface → LAG-number map via `interface.lag`. When a channel's members already belong to a LAG, reuse that number; otherwise allocate the interface-derived number, pre-seeding the used set with existing LAG numbers so a new channel never grabs one an existing LAG already holds.

The first pair to touch a device still keeps its natural interface-derived number, so behaviour is unchanged on first run and wherever there is no existing LAG state.

## Alternatives considered

- **Correlate by peer switch** rather than by member interface — it would also survive a full recable of a bundle onto different ports, but requires walking each existing LAG member's `connected_endpoints` and adds a dependency on endpoint data quality. Rejected as more surface area than the bug needs; member-based correlation already fixes the add/remove churn.
- **Cleaning up the LAG left behind when a channel is removed entirely** is out of scope. The tool has no selective deletion path (only the destructive `purge` command), so the orphaned LAG is left in place — consistent with the generator only ever creating and assigning.

## Tests

- Three regression tests for the collision — Arista/Dell modular, Cisco stackable, and digit-less naming — each asserting the two LAGs on a shared switch resolve to distinct names.
- Two regression tests for stability: a surviving channel reuses its existing `PortChannel2` instead of shifting to `PortChannel1`, and a new channel bumps past an existing `PortChannel1`. The `make_interface` fixture gains a `lag` attribute to express member-to-LAG back-references.

- `pytest tests/unit` → green
- `flake8`, `black --check`, `mypy` → clean on the change

## Context

This is the latent edge case flagged as a follow-up during the co-review of the Tier-5 test PR:

- osism/netbox-manager#271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
