### PR TITLE
Ignore dist/ and build/ so release wheels keep the tag version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ settings.toml
 __pycache__/
 *.egg-info/
 .pytest_cache/
+build/
+dist/


### PR DESCRIPTION
## Problem

The `publish-pypi-package` job has failed with `400 Bad Request` from PyPI since v0.20260706.0 — the latest version on PyPI is still 0.20260614.0.

The job builds the sdist and the wheel from the same checkout. The sdist lands in `dist/`, which was untracked, so by the time the wheel was built, setuptools-git-versioning (whose `is_dirty()` checks `git status --short`, including untracked files) saw a dirty worktree and applied `dirty_template` even though HEAD was exactly on the release tag. The wheel was versioned `0.20260810.0.post0+git.416f7b22.dirty` — a PEP 440 local version, which PyPI rejects.

This started with the `dirty_template` change in 249344f, whose assumption that tagged release builds are unaffected did not hold in the release job.

## Fix

Ignore `dist/` and `build/` so the build's own artifacts no longer mark the worktree dirty and tagged builds produce the bare tag version again. Ignored files do not show up in `git status --short`, verified locally.

After merging, the release needs to be re-tagged so the publish job runs again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)